### PR TITLE
Update rust code for newer versions of switchboard-on-demand crate

### DIFF
--- a/product-documentation/data-feeds/solana-svm/part-3-integrating-your-feed/integrating-your-feed-on-chain.md
+++ b/product-documentation/data-feeds/solana-svm/part-3-integrating-your-feed/integrating-your-feed-on-chain.md
@@ -24,6 +24,7 @@ This section guides you through the process of incorporating Switchboard data fe
     Include the pull feed account in an instruction within your program. The following example demonstrates how to access and utilise Switchboard data in your Solana program using Rust:
 
     ```rust
+    use anchor_lang::prelude::*;
     // Switchboard import
     use switchboard_on_demand::on_demand::accounts::pull_feed::PullFeedAccountData;
 
@@ -42,6 +43,8 @@ This section guides you through the process of incorporating Switchboard data fe
             // Feed account data
             let feed_account = ctx.accounts.feed.data.borrow();
 
+            let clock = Clock::get()?;
+
             // Verify that this account is the intended one by comparing public keys
             // if ctx.accounts.feed.key != &specific_pubkey {
             //     throwSomeError
@@ -50,7 +53,7 @@ This section guides you through the process of incorporating Switchboard data fe
             // Docs at: https://switchboard-on-demand-rust-docs.web.app/on_demand/accounts/pull_feed/struct.PullFeedAccountData.html
             let feed = PullFeedAccountData::parse(feed_account).unwrap();
             // Log the value
-            msg!("price: {:?}", feed.value());
+            msg!("price: {:?}", feed.value(&clock));
             Ok(())
         }
     }


### PR DESCRIPTION
feed.value() now expects an argument of type `&anchor_lang::prelude::Clock` 

pull_feed.rs(386, 12): method defined here

   ```rust
    /// The median value of the submissions needed for quorom size
    /// Fails if the result is not valid or stale.
    pub fn value(&self, clock: &Clock) -> Result<Decimal, OnDemandError> {
        if self.result.result_slot().unwrap_or(0) < clock.slot - self.max_staleness as u64 {
            return Err(OnDemandError::StaleResult);
        }
        self.result.value().ok_or(OnDemandError::StaleResult)
    }

```