### PR TITLE
Update all Discord invite links to new URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ Why use Switchboard? Our protocol is designed around 4 principles:
 * **Secure and Private**
   * Switchboard prevents anyone, including node operators, from altering, exposing or frontrunning your data. Inside Trusted Execution Environments (TEEs), your code and data stay safe and secure.
 
-The Switchboard Protocol is [open-source](https://github.com/switchboard-xyz) and contributions are welcome. Need help using Switchboard? Our support team is available around the clock on [Discord](https://discord.gg/switchboardxyz).
+The Switchboard Protocol is [open-source](https://github.com/switchboard-xyz) and contributions are welcome. Need help using Switchboard? Our support team is available around the clock on [Discord](https://discord.gg/EyBm9a3bYm).
 

--- a/custom-feeds/advanced-feed-configuration/faq.md
+++ b/custom-feeds/advanced-feed-configuration/faq.md
@@ -12,4 +12,4 @@ Exchanges with low liquidity/volume can become manipulable by bad actors if smal
 
 ## How do I get a new Task Type added?
 
-It's recommended to exhaust all options for fetching the data you desire using existing task types before requesting new task types, but if it requires a custom On-Chain SDK, please [reach out ](https://discord.com/invite/switchboardxyz)and it can get added to the roadmap.
+It's recommended to exhaust all options for fetching the data you desire using existing task types before requesting new task types, but if it requires a custom On-Chain SDK, please [reach out ](https://discord.gg/EyBm9a3bYm)and it can get added to the roadmap.

--- a/docs-by-chain/evm/price-feeds/price-feeds-tutorial.md
+++ b/docs-by-chain/evm/price-feeds/price-feeds-tutorial.md
@@ -605,4 +605,4 @@ Popular feeds include:
 
 - Explore [randomness integration](../randomness.md) for gaming and NFTs
 - Learn about [custom feeds](../../../custom-feeds/build-and-deploy-feed/README.md) for specialized data
-- Join the [Switchboard Discord](https://discord.gg/switchboardxyz) for support
+- Join the [Switchboard Discord](https://discord.gg/EyBm9a3bYm) for support

--- a/docs-by-chain/evm/surge/README.md
+++ b/docs-by-chain/evm/surge/README.md
@@ -266,4 +266,4 @@ The SDK includes automatic reconnection logic with exponential backoff. Your app
 * [Surge Tutorial](surge-tutorial.md) - Step-by-step implementation guide
 * [Crossbar Gateway](../../../tooling/crossbar/README.md) - Stream prices to your frontend
 * [Explore code examples](https://github.com/switchboard-xyz/sb-on-demand-examples)
-* [Join our Discord](https://discord.gg/switchboard)
+* [Join our Discord](https://discord.gg/EyBm9a3bYm)

--- a/docs-by-chain/solana-svm/surge/README.md
+++ b/docs-by-chain/solana-svm/surge/README.md
@@ -282,4 +282,4 @@ The SDK includes automatic reconnection logic with exponential backoff. Your app
 * [Surge Tutorial](surge.md) - Step-by-step implementation guide
 * [Crossbar Gateway](../../../tooling/crossbar/README.md) - Stream prices to your frontend
 * [Explore code examples](https://github.com/switchboard-xyz/sb-on-demand-examples)
-* [Join our Discord](https://discord.gg/switchboard)
+* [Join our Discord](https://discord.gg/EyBm9a3bYm)

--- a/docs-by-chain/solana-svm/surge/surge.md
+++ b/docs-by-chain/solana-svm/surge/surge.md
@@ -227,4 +227,4 @@ surge.on('close', () => {
 
 - Explore [code examples](https://github.com/switchboard-xyz/sb-on-demand-examples)
 - Learn about [Crossbar gateway](../../../tooling/crossbar/README.md)
-- Join our [Discord](https://discord.gg/switchboard) for support
+- Join our [Discord](https://discord.gg/EyBm9a3bYm) for support

--- a/docs-by-chain/solana-svm/x402/x402-tutorial.md
+++ b/docs-by-chain/solana-svm/x402/x402-tutorial.md
@@ -293,4 +293,4 @@ Simulation succeeded!
 - Learn about [Variable Overrides](../../../custom-feeds/advanced-feed-configuration/data-feed-variable-overrides.md) for other dynamic patterns
 - Explore [Custom Feeds](../../../custom-feeds/build-and-deploy-feed/README.md) for building your own oracle jobs
 - Check out other [Solana examples](https://github.com/switchboard-xyz/sb-on-demand-examples/tree/main/solana)
-- Join our [Discord](https://discord.gg/switchboard) for support
+- Join our [Discord](https://discord.gg/EyBm9a3bYm) for support

--- a/docs-by-chain/sui/surge/README.md
+++ b/docs-by-chain/sui/surge/README.md
@@ -287,4 +287,4 @@ The SDK includes automatic reconnection logic with exponential backoff. Your app
 * [Surge Tutorial](surge-tutorial.md) - Step-by-step implementation guide
 * [Crossbar Gateway](../../../tooling/crossbar/README.md) - Stream prices to your frontend
 * [Explore code examples](https://github.com/switchboard-xyz/sui)
-* [Join our Discord](https://discord.gg/switchboard)
+* [Join our Discord](https://discord.gg/EyBm9a3bYm)

--- a/how-it-works/switchboard-protocol/governance-and-tokenomics.md
+++ b/how-it-works/switchboard-protocol/governance-and-tokenomics.md
@@ -151,7 +151,7 @@ Whether you've participated in Switchboard Orbs points programs, staked with Fra
 
 * **Official Website**: [switchboard.xyz](https://switchboard.xyz)
 * **Twitter/X**: [@switchboardxyz](https://x.com/switchboardxyz)
-* **Discord**: [discord.gg/switchboardxyz](https://discord.gg/switchboardxyz)
+* **Discord**: [discord.gg/EyBm9a3bYm](https://discord.gg/EyBm9a3bYm)
 * **Medium Blog**: [switchboardxyz.medium.com](https://switchboardxyz.medium.com/)
 * **GitHub**: [github.com/switchboard-xyz](https://github.com/switchboard-xyz)
 * **YouTube**: [@SwitchboardFoundationGroup](https://www.youtube.com/@SwitchboardFoundationGroup)

--- a/how-it-works/switchboard-protocol/swtch-token-overview.md
+++ b/how-it-works/switchboard-protocol/swtch-token-overview.md
@@ -99,7 +99,7 @@ SWTCH is the governance and utility token that powers the Switchboard oracle net
 
 ## Community & Support
 
-* **Discord**: [discord.gg/switchboardxyz](https://discord.gg/switchboardxyz)
+* **Discord**: [discord.gg/EyBm9a3bYm](https://discord.gg/EyBm9a3bYm)
 * **Twitter**: [@switchboardxyz](https://x.com/switchboardxyz)
 * **Foundation**: [switchboard.foundation](https://switchboard.foundation/)
 


### PR DESCRIPTION
Replace various Discord invite links (switchboardxyz, switchboard) with the new canonical invite link across all documentation.