### PR TITLE
Fix links for Mainnet and Testnet addresses

### DIFF
--- a/docs-by-chain/aptos/aptos.md
+++ b/docs-by-chain/aptos/aptos.md
@@ -7,9 +7,9 @@ This guide covers the setup and use of Switchboard data feeds within your projec
 Switchboard is currently deployed on the following networks:
 
 * Mainnet:
-  * [`0xfea54925b5ac1912331e2e62049849b37842efaea298118b66f85a590577528`](https://explorer.aptoslabs.com/object/0xfea54925b5ac1912331e2e62049849b37842efaea298118b66f85a59057752b8/modules/code/aggregator?network=mainnet)
+  * [`0xfea54925b5ac1912331e2e62049849b37842efaea298118b66f85a59057752b8`](https://explorer.aptoslabs.com/object/0xfea54925b5ac1912331e2e62049849b37842efaea298118b66f85a59057752b8/modules/code/aggregator?network=mainnet)
 * Testnet:
-  * [`0x81fc6bbc64b7968e631b2a5b3a88652f91a617534e3755efab2f572858a3099`](https://explorer.aptoslabs.com/object/0x4fc1809ffb3c5ada6b4e885d4dbdbeb70cbdd99cbc0c8485965d95c2eab90935/modules/code/aggregator?network=testnet)
+  * [`0x4fc1809ffb3c5ada6b4e885d4dbdbeb70cbdd99cbc0c8485965d95c2eab90935`](https://explorer.aptoslabs.com/object/0x4fc1809ffb3c5ada6b4e885d4dbdbeb70cbdd99cbc0c8485965d95c2eab90935/modules/code/aggregator?network=testnet)
 
 **Typescript-SDK Installation**
 


### PR DESCRIPTION
There was a typo in mainnet address. The testnet address was wrong.