### PR TITLE
Update Monad testnet Switchboard address

### DIFF
--- a/docs-by-chain/evm/README.md
+++ b/docs-by-chain/evm/README.md
@@ -17,6 +17,6 @@ The Switchboard contract has been deployed to the following EVM networks:
 | Core | Testnet | 1114 | `0x2f833D73bA1086F3E5CDE9e9a695783984636A76` |
 | HyperEVM | Mainnet | 999 | `0xcDb299Cb902D1E39F83F54c7725f54eDDa7F3347` |
 | Monad | Mainnet | 143 | `0xB7F03eee7B9F56347e32cC71DaD65B303D5a0E67` |
-| Monad | Testnet | 10143 | `0xD3860E2C66cBd5c969Fa7343e6912Eff0416bA33` |
+| Monad | Testnet | 10143 | `0x6724818814927e057a693f4e3A172b6cC1eA690C` |
 | Morph | Mainnet | - | `0x33A5066f65f66161bEb3f827A3e40fce7d7A2e6C` |
 | Morph | Holesky | - | `0x3c1604DF82FDc873D289a47c6bb07AFA21f299e5` |

--- a/docs-by-chain/evm/monad.md
+++ b/docs-by-chain/evm/monad.md
@@ -7,7 +7,7 @@ Monad is a high-performance EVM-compatible blockchain optimized for speed and ef
 | Network | Chain ID | RPC URL | Switchboard Contract |
 |---------|----------|---------|---------------------|
 | **Mainnet** | 143 | `https://rpc-mainnet.monadinfra.com/rpc/YOUR_API_KEY` | `0xB7F03eee7B9F56347e32cC71DaD65B303D5a0E67` |
-| **Testnet** | 10143 | `https://testnet-rpc.monad.xyz` | `0xD3860E2C66cBd5c969Fa7343e6912Eff0416bA33` |
+| **Testnet** | 10143 | `https://testnet-rpc.monad.xyz` | `0x6724818814927e057a693f4e3A172b6cC1eA690C` |
 
 ## Quick Start
 
@@ -76,7 +76,7 @@ const provider = new ethers.JsonRpcProvider('https://testnet-rpc.monad.xyz');
 const signer = new ethers.Wallet(process.env.PRIVATE_KEY!, provider);
 
 // Switchboard contract on Monad Testnet
-const switchboardAddress = '0xD3860E2C66cBd5c969Fa7343e6912Eff0416bA33';
+const switchboardAddress = '0x6724818814927e057a693f4e3A172b6cC1eA690C';
 const switchboard = new ethers.Contract(switchboardAddress, SWITCHBOARD_ABI, signer);
 
 // Fetch and update prices

--- a/docs-by-chain/evm/price-feeds/price-feeds-tutorial.md
+++ b/docs-by-chain/evm/price-feeds/price-feeds-tutorial.md
@@ -397,7 +397,7 @@ import "../src/SwitchboardPriceConsumer.sol";
 
 contract Deploy is Script {
     // Switchboard addresses by network
-    address constant MONAD_TESTNET = 0xD3860E2C66cBd5c969Fa7343e6912Eff0416bA33;
+    address constant MONAD_TESTNET = 0x6724818814927e057a693f4e3A172b6cC1eA690C;
     address constant MONAD_MAINNET = 0xB7F03eee7B9F56347e32cC71DaD65B303D5a0E67;
     address constant HYPERLIQUID_MAINNET = 0xcDb299Cb902D1E39F83F54c7725f54eDDa7F3347;
 
@@ -577,7 +577,7 @@ function shouldLiquidate(
 
 | Network | Chain ID | Switchboard Contract |
 |---------|----------|---------------------|
-| Monad Testnet | 10143 | `0xD3860E2C66cBd5c969Fa7343e6912Eff0416bA33` |
+| Monad Testnet | 10143 | `0x6724818814927e057a693f4e3A172b6cC1eA690C` |
 | Monad Mainnet | 143 | `0xB7F03eee7B9F56347e32cC71DaD65B303D5a0E67` |
 | HyperEVM Mainnet | 999 | `0xcDb299Cb902D1E39F83F54c7725f54eDDa7F3347` |
 | Arbitrum One | 42161 | `0xAd9b8604b6B97187CDe9E826cDeB7033C8C37198` |


### PR DESCRIPTION
## Summary
- replace the old Monad testnet Switchboard proxy address in EVM docs
- point Monad docs and price feed examples at 0x6724818814927e057a693f4e3A172b6cC1eA690C

## Testing
- not run (address-only documentation update)