### PR TITLE
Refresh EVM docs for current example flows

### DIFF
--- a/docs-by-chain/evm/hyperliquid.md
+++ b/docs-by-chain/evm/hyperliquid.md
@@ -15,8 +15,9 @@ Hyperliquid is a high-performance Layer 1 blockchain with native perpetual futur
 
 ```bash
 git clone https://github.com/switchboard-xyz/sb-on-demand-examples.git
-cd sb-on-demand-examples/evm
+cd sb-on-demand-examples/evm/price-feeds
 bun install
+forge build
 ```
 
 ### 2. Configure Your Wallet
@@ -37,6 +38,7 @@ Create a `.env` file for scripts (add to `.gitignore`):
 PRIVATE_KEY=0xyour_private_key_here
 RPC_URL=https://rpc.hyperliquid.xyz/evm
 NETWORK=hyperliquid-mainnet
+# Optional: if omitted, the example deploys a new consumer contract for you
 CONTRACT_ADDRESS=0xyour_contract_address
 ```
 
@@ -44,49 +46,64 @@ CONTRACT_ADDRESS=0xyour_contract_address
 
 ```bash
 # Mainnet
-forge script script/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
+SWITCHBOARD_ADDRESS=0xcDb299Cb902D1E39F83F54c7725f54eDDa7F3347 \
+forge script deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
   --rpc-url https://rpc.hyperliquid.xyz/evm \
-  --account mykey \
+  --private-key $PRIVATE_KEY \
   --broadcast -vvvv
 
-# Testnet
-forge script script/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
-  --rpc-url https://rpc.hyperliquid-testnet.xyz/evm \
-  --account mykey \
-  --broadcast -vvvv
 ```
+
+Hyperliquid testnet remains `TBD` in the deployment table above, so the packaged examples currently only have a documented Hyperliquid mainnet path.
 
 ### 4. Run Examples
 
 ```bash
 # Price Feeds (reads from .env)
-bun scripts/run.ts
+bun run example
 
-# Randomness (reads from .env)
-bun run randomness
+# Direct randomness example
+cd ../randomness
+bun install
+PRIVATE_KEY=0x... NETWORK=hyperliquid-mainnet bun run example
 ```
 
 ## Integration Example
 
 ```typescript
 import { ethers } from 'ethers';
-import { CrossbarClient, SWITCHBOARD_ABI } from '@switchboard-xyz/common';
+import { CrossbarClient } from '@switchboard-xyz/common';
 
 const provider = new ethers.JsonRpcProvider('https://rpc.hyperliquid.xyz/evm');
 const signer = new ethers.Wallet(process.env.PRIVATE_KEY!, provider);
 
 // Switchboard contract on Hyperliquid Mainnet
 const switchboardAddress = '0xcDb299Cb902D1E39F83F54c7725f54eDDa7F3347';
-const switchboard = new ethers.Contract(switchboardAddress, SWITCHBOARD_ABI, signer);
+const switchboard = new ethers.Contract(
+  switchboardAddress,
+  ['function getFee(bytes[] calldata updates) external view returns (uint256)'],
+  signer
+);
+const priceConsumer = new ethers.Contract(
+  process.env.CONTRACT_ADDRESS!,
+  [
+    'function updatePrices(bytes[] calldata updates, bytes32[] calldata feedIds) external payable',
+    'function getPrice(bytes32 feedId) external view returns (int128 value, uint256 timestamp, uint64 slotNumber)'
+  ],
+  signer
+);
 
 // Fetch and update prices for perpetual futures
 const crossbar = new CrossbarClient('https://crossbar.switchboard.xyz');
 const btcFeedHash = '0x4cd1cad962425681af07b9254b7d804de3ca3446fbfd1371bb258d2c75059812'; // BTC/USD
 
-const response = await crossbar.fetchOracleQuote([btcFeedHash], 'mainnet');
-const fee = await switchboard.getFee([response.encoded]);
+const response = await crossbar.fetchEVMResults({
+  chainId: 999,
+  aggregatorIds: [btcFeedHash],
+});
+const fee = await switchboard.getFee(response.encoded);
 
-const tx = await priceConsumer.updatePrices([response.encoded], { value: fee });
+const tx = await priceConsumer.updatePrices(response.encoded, [btcFeedHash], { value: fee });
 const receipt = await tx.wait();
 
 console.log(`Price updated on Hyperliquid! Block: ${receipt.blockNumber}`);

--- a/docs-by-chain/evm/monad.md
+++ b/docs-by-chain/evm/monad.md
@@ -1,6 +1,6 @@
 # Monad Integration
 
-Monad is a high-performance EVM-compatible blockchain optimized for speed and efficiency. Switchboard On-Demand provides native oracle support for Monad with the same security guarantees and ease of use as other EVM chains.
+Monad is the primary EVM test network exercised by the current `sb-on-demand-examples` repo. The verified Monad testnet Switchboard proxy is `0x6724818814927e057a693f4e3A172b6cC1eA690C`.
 
 ## Network Information
 
@@ -11,99 +11,141 @@ Monad is a high-performance EVM-compatible blockchain optimized for speed and ef
 
 ## Quick Start
 
-### 1. Clone the Examples Repository
+### Price Feeds
 
 ```bash
 git clone https://github.com/switchboard-xyz/sb-on-demand-examples.git
-cd sb-on-demand-examples/evm
+cd sb-on-demand-examples/evm/price-feeds
 bun install
+forge build
+cp .env.example .env
 ```
 
-### 2. Configure Your Wallet
-
-> **Security:** Never use `export PRIVATE_KEY=...` or pass private keys as command-line arguments—they appear in shell history and process listings.
-
-Import your private key into Foundry's encrypted keystore:
-
-```bash
-cast wallet import mykey --interactive
-# Enter your private key when prompted (hidden from terminal)
-# Set a password to encrypt the keystore
-```
-
-Create a `.env` file for scripts (add to `.gitignore`):
+Set your `.env` like this:
 
 ```bash
 PRIVATE_KEY=0xyour_private_key_here
 RPC_URL=https://testnet-rpc.monad.xyz
 NETWORK=monad-testnet
-CONTRACT_ADDRESS=0xyour_contract_address
+# Optional: if omitted, the example deploys a new consumer contract for you
+CONTRACT_ADDRESS=0xyour_existing_consumer
 ```
 
-### 3. Deploy Contract
+Then run:
 
 ```bash
-# Testnet
-forge script script/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
+bun run example
+```
+
+This flow was verified on Monad testnet. The packaged script now handles the current Crossbar Monad testnet rollout by falling back to the network-agnostic oracle quote endpoint if the chain-specific feed lookup is unavailable.
+
+### Direct Randomness
+
+```bash
+cd ../randomness
+bun install
+PRIVATE_KEY=0xyour_private_key_here bun run example
+```
+
+That example talks directly to the Switchboard proxy, creates a randomness request, waits for the settlement window, resolves through Crossbar, and settles on-chain.
+
+### Coin Flip
+
+```bash
+cd coin-flip
+bun install
+forge build
+forge script deploy/CoinFlip.s.sol:CoinFlipScript \
   --rpc-url https://testnet-rpc.monad.xyz \
-  --account mykey \
-  --broadcast -vvvv
-
-# Mainnet
-forge script script/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
-  --rpc-url https://rpc-mainnet.monadinfra.com/rpc/YOUR_API_KEY \
-  --account mykey \
-  --broadcast -vvvv
+  --private-key $PRIVATE_KEY \
+  --broadcast
 ```
 
-### 4. Run Examples
+After deployment, fund the example contract with a small bankroll so it can pay winning flips:
 
 ```bash
-# Price Feeds (reads from .env)
-bun scripts/run.ts
-
-# Randomness (reads from .env)
-bun run randomness
+cast send $COIN_FLIP_CONTRACT_ADDRESS \
+  --rpc-url https://testnet-rpc.monad.xyz \
+  --private-key $PRIVATE_KEY \
+  --value 0.05ether
 ```
+
+Set your `.env`:
+
+```bash
+PRIVATE_KEY=0xyour_private_key_here
+RPC_URL=https://testnet-rpc.monad.xyz
+COIN_FLIP_CONTRACT_ADDRESS=0xyour_deployed_contract
+WAGER_AMOUNT=0.01
+```
+
+Run the game script:
+
+```bash
+bun run flip
+```
+
+### Pancake Stacker
+
+```bash
+cd ../pancake-stacker
+bun install
+forge build
+forge script deploy/PancakeStacker.s.sol:PancakeStackerScript \
+  --rpc-url https://testnet-rpc.monad.xyz \
+  --private-key $PRIVATE_KEY \
+  --broadcast
+```
+
+Set your `.env`:
+
+```bash
+PRIVATE_KEY=0xyour_private_key_here
+RPC_URL=https://testnet-rpc.monad.xyz
+PANCAKE_STACKER_CONTRACT_ADDRESS=0xyour_deployed_contract
+```
+
+Then run:
+
+```bash
+bun run flip
+```
+
+If a previous run already created a pending flip, the packaged script resumes settlement instead of failing.
 
 ## Integration Example
 
 ```typescript
-import { ethers } from 'ethers';
-import { CrossbarClient, SWITCHBOARD_ABI } from '@switchboard-xyz/common';
+import { ethers } from "ethers";
+import { CrossbarClient } from "@switchboard-xyz/common";
 
-const provider = new ethers.JsonRpcProvider('https://testnet-rpc.monad.xyz');
+const provider = new ethers.JsonRpcProvider("https://testnet-rpc.monad.xyz");
 const signer = new ethers.Wallet(process.env.PRIVATE_KEY!, provider);
 
-// Switchboard contract on Monad Testnet
-const switchboardAddress = '0x6724818814927e057a693f4e3A172b6cC1eA690C';
-const switchboard = new ethers.Contract(switchboardAddress, SWITCHBOARD_ABI, signer);
+const switchboard = new ethers.Contract(
+  "0x6724818814927e057a693f4e3A172b6cC1eA690C",
+  ["function getFee(bytes[] calldata updates) external view returns (uint256)"],
+  signer
+);
 
-// Fetch and update prices
-const crossbar = new CrossbarClient('https://crossbar.switchboard.xyz');
-const feedHash = '0xa0950ee5ee117b2e2c30f154a69e17bfb489a7610c508dc5f67eb2a14616d8ea'; // ETH/USD
+const priceConsumer = new ethers.Contract(
+  process.env.CONTRACT_ADDRESS!,
+  ["function updatePrices(bytes[] calldata updates, bytes32[] calldata feedIds) external payable"],
+  signer
+);
 
-const response = await crossbar.fetchOracleQuote([feedHash], 'mainnet');
-const fee = await switchboard.getFee([response.encoded]);
+const crossbar = new CrossbarClient("https://crossbar.switchboard.xyz");
+const feedHash = "0xa0950ee5ee117b2e2c30f154a69e17bfb489a7610c508dc5f67eb2a14616d8ea";
 
-const tx = await priceConsumer.updatePrices([response.encoded], { value: fee });
-const receipt = await tx.wait();
+const response = await crossbar.fetchOracleQuote([feedHash], "mainnet");
+const updates = [response.encoded];
+const fee = await switchboard.getFee(updates);
 
-console.log(`Price updated on Monad! Block: ${receipt.blockNumber}`);
+await priceConsumer.updatePrices(updates, [feedHash], { value: fee });
 ```
 
-## Monad-Specific Considerations
+## Monad Notes
 
-- **Native Token**: MON (for gas fees)
-- **High Performance**: Monad's optimized execution enables faster oracle updates
-- **Low Fees**: Efficient gas usage for frequent price updates
-- **EVM Compatibility**: All existing Ethereum tooling works seamlessly
-
-## Getting MON Tokens
-
-**Testnet:**
-- Use the [Monad Testnet Faucet](https://faucet.monad.xyz) to get testnet MON
-
-**Mainnet:**
-- Acquire MON tokens through supported exchanges
-- Bridge from other networks using official Monad bridges
+- `MON` is the native gas token on Monad.
+- The current examples repo is organized as standalone subprojects under `evm/price-feeds`, `evm/randomness`, `evm/randomness/coin-flip`, and `evm/randomness/pancake-stacker`.
+- Testnet MON is available from the [Monad faucet](https://faucet.monad.xyz).

--- a/docs-by-chain/evm/price-feeds/price-feeds-tutorial.md
+++ b/docs-by-chain/evm/price-feeds/price-feeds-tutorial.md
@@ -386,51 +386,30 @@ After confirmation, you can:
 
 ### Using Foundry
 
-Create a deploy script `script/Deploy.s.sol`:
-
-```solidity
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.22;
-
-import "forge-std/Script.sol";
-import "../src/SwitchboardPriceConsumer.sol";
-
-contract Deploy is Script {
-    // Switchboard addresses by network
-    address constant MONAD_TESTNET = 0x6724818814927e057a693f4e3A172b6cC1eA690C;
-    address constant MONAD_MAINNET = 0xB7F03eee7B9F56347e32cC71DaD65B303D5a0E67;
-    address constant HYPERLIQUID_MAINNET = 0xcDb299Cb902D1E39F83F54c7725f54eDDa7F3347;
-
-    function run() external {
-        address switchboardAddress = MONAD_TESTNET; // Change as needed
-
-        vm.startBroadcast();
-        SwitchboardPriceConsumer consumer = new SwitchboardPriceConsumer(switchboardAddress);
-        vm.stopBroadcast();
-
-        console.log("Deployed at:", address(consumer));
-    }
-}
-```
+The examples repo already includes a deploy script at `deploy/DeploySwitchboardPriceConsumer.s.sol`.
 
 ### Deploy Commands
 
 ```bash
 # Monad Testnet
-forge script script/Deploy.s.sol:Deploy \
+forge script deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
   --rpc-url https://testnet-rpc.monad.xyz \
+  --private-key $PRIVATE_KEY \
   --broadcast \
   -vvvv
 
 # Monad Mainnet
-forge script script/Deploy.s.sol:Deploy \
+forge script deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
   --rpc-url https://rpc-mainnet.monadinfra.com/rpc/YOUR_KEY \
+  --private-key $PRIVATE_KEY \
   --broadcast \
   -vvvv
 
 # HyperEVM Mainnet
-forge script script/Deploy.s.sol:Deploy \
+SWITCHBOARD_ADDRESS=0xcDb299Cb902D1E39F83F54c7725f54eDDa7F3347 \
+forge script deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
   --rpc-url https://rpc.hyperliquid.xyz/evm \
+  --private-key $PRIVATE_KEY \
   --broadcast \
   -vvvv
 ```
@@ -441,14 +420,14 @@ forge script script/Deploy.s.sol:Deploy \
 
 ```bash
 git clone https://github.com/switchboard-xyz/sb-on-demand-examples
-cd sb-on-demand-examples/evm
+cd sb-on-demand-examples/evm/price-feeds
 ```
 
 ### 2. Install Dependencies
 
 ```bash
 bun install
-forge install
+forge build
 ```
 
 ### 3. Configure Environment
@@ -459,13 +438,16 @@ Create a `.env` file (add to `.gitignore`):
 
 ```bash
 PRIVATE_KEY=0x...
-EXAMPLE_ADDRESS=0x...  # Your deployed contract
+RPC_URL=https://testnet-rpc.monad.xyz
+NETWORK=monad-testnet
+# Optional: if omitted, the script deploys a new consumer contract for you
+CONTRACT_ADDRESS=0x...
 ```
 
 ### 4. Run the Example
 
 ```bash
-bun run examples/updateFeed.ts
+bun run example
 ```
 
 ### Expected Output
@@ -493,7 +475,7 @@ Timestamp: 2024-12-18T10:30:00.000Z
 Copy the interface files from the examples repo:
 
 ```bash
-cp -r sb-on-demand-examples/evm/src/switchboard your-project/src/
+cp -r sb-on-demand-examples/evm/price-feeds/src/switchboard your-project/src/
 ```
 
 Or install via npm:

--- a/docs-by-chain/evm/price-feeds/price-feeds-tutorial.md
+++ b/docs-by-chain/evm/price-feeds/price-feeds-tutorial.md
@@ -293,17 +293,27 @@ Here's a complete client that fetches oracle data and submits it to your contrac
 
 ```typescript
 import * as ethers from "ethers";
-import { CrossbarClient, SWITCHBOARD_ABI } from "@switchboard-xyz/common";
+import { CrossbarClient } from "@switchboard-xyz/common";
 
 async function main() {
   // Setup
   const privateKey = process.env.PRIVATE_KEY!;
   const contractAddress = process.env.CONTRACT_ADDRESS!;
+  const switchboardAddress = process.env.SWITCHBOARD_ADDRESS!;
 
   const provider = new ethers.JsonRpcProvider("https://rpc.hyperliquid.xyz/evm");
   const signer = new ethers.Wallet(privateKey, provider);
 
-  const contract = new ethers.Contract(contractAddress, SWITCHBOARD_ABI, signer);
+  const consumerAbi = [
+    "function updatePrices(bytes[] calldata updates, bytes32[] calldata feedIds) external payable",
+    "event PriceUpdated(bytes32 indexed feedId, int128 oldPrice, int128 newPrice, uint256 timestamp, uint64 slotNumber)"
+  ];
+  const switchboardAbi = [
+    "function getFee(bytes[] calldata updates) external view returns (uint256)"
+  ];
+
+  const contract = new ethers.Contract(contractAddress, consumerAbi, signer);
+  const switchboard = new ethers.Contract(switchboardAddress, switchboardAbi, signer);
   const crossbar = new CrossbarClient("https://crossbar.switchboard.xyz");
 
   // The feed ID you want to update (e.g., BTC/USD)
@@ -318,7 +328,8 @@ async function main() {
   console.log("Fetched", encoded.length, "encoded updates");
 
   // Step 2: Submit to your contract
-  const tx = await contract.updatePrices(encoded, [feedId]);
+  const fee = await switchboard.getFee(encoded);
+  const tx = await contract.updatePrices(encoded, [feedId], { value: fee });
   console.log("Transaction hash:", tx.hash);
 
   // Step 3: Wait for confirmation
@@ -326,7 +337,7 @@ async function main() {
   console.log("Confirmed in block:", receipt.blockNumber);
 
   // Step 4: Parse events
-  const iface = new ethers.Interface(SWITCHBOARD_ABI);
+  const iface = new ethers.Interface(consumerAbi);
   for (const log of receipt.logs) {
     try {
       const parsed = iface.parseLog({ topics: log.topics, data: log.data });

--- a/docs-by-chain/evm/randomness/randomness-tutorial.md
+++ b/docs-by-chain/evm/randomness/randomness-tutorial.md
@@ -210,7 +210,7 @@ This view function provides the data needed for off-chain resolution:
 
 ## The Off-Chain Script
 
-The `stack-pancake.ts` script demonstrates how to interact with the contract from off-chain. While the example repository also includes a React UI, the script is simpler to understand and follows the exact same flow.
+The `stackPancake.ts` script demonstrates how to interact with the contract from off-chain. While the example repository also includes a React UI, the script is simpler to understand and follows the exact same flow.
 
 > **Note**: The UI code does the same thing as this script, but with React state management and a visual interface. Understanding this script is sufficient to understand how any client (UI, bot, etc.) interacts with the randomness system.
 
@@ -233,7 +233,7 @@ const PANCAKE_STACKER_ABI = [
 
 async function main() {
     // Initialize providers
-    const rpcUrl = process.env.RPC_URL || "https://rpc.monad.xyz";
+    const rpcUrl = process.env.RPC_URL || "https://testnet-rpc.monad.xyz";
     const provider = new ethers.JsonRpcProvider(rpcUrl);
     const wallet = new ethers.Wallet(process.env.PRIVATE_KEY!, provider);
     const crossbar = new CrossbarClient("https://crossbar.switchboard.xyz");
@@ -255,10 +255,15 @@ async function main() {
 ### Step 2: Request Randomness (Flip the Pancake)
 
 ```typescript
-    // Call flipPancake() to request randomness
-    const tx = await contract.flipPancake();
-    await tx.wait();
-    console.log("Flip requested:", tx.hash);
+    const [, hasPendingFlip] = await contract.getPlayerStats(wallet.address);
+
+    if (hasPendingFlip) {
+        console.log("Found pending flip, resuming settlement...");
+    } else {
+        const tx = await contract.flipPancake();
+        await tx.wait();
+        console.log("Flip requested:", tx.hash);
+    }
 ```
 
 This triggers the **Request Randomness** phase on-chain.
@@ -294,6 +299,8 @@ The contract returns:
 ```
 
 This is where **Crossbar** talks to the **Oracle** and returns the encoded randomness proof.
+
+In practice you should wait until `rollTimestamp + minSettlementDelay` before calling Crossbar. The packaged example script adds a small buffer and resumes an already-pending flip if a previous run stopped after requesting randomness.
 
 ### Step 5: Settle On-Chain (Catch the Pancake)
 
@@ -422,7 +429,8 @@ The contract gracefully handles settlement failures by catching exceptions and r
 ```bash
 git clone https://github.com/switchboard-xyz/sb-on-demand-examples
 cd sb-on-demand-examples/evm/randomness/pancake-stacker
-bun install  # or npm install
+bun install
+forge build
 ```
 
 ### 2. Configure Your Wallet
@@ -437,8 +445,10 @@ cast wallet import mykey --interactive
 ### 3. Deploy the Contract
 
 ```bash
-# Deploy (adjust for your target chain)
-forge script script/PancakeStacker.s.sol --rpc-url https://rpc.monad.xyz --account mykey --broadcast
+forge script deploy/PancakeStacker.s.sol:PancakeStackerScript \
+  --rpc-url https://testnet-rpc.monad.xyz \
+  --private-key $PRIVATE_KEY \
+  --broadcast
 ```
 
 ### 4. Run the Script
@@ -448,11 +458,11 @@ Create a `.env` file (add to `.gitignore`):
 ```bash
 PRIVATE_KEY=0x...
 PANCAKE_STACKER_CONTRACT_ADDRESS=0x_your_deployed_address
-RPC_URL=https://rpc.monad.xyz
+RPC_URL=https://testnet-rpc.monad.xyz
 ```
 
 ```bash
-bun scripts/stack-pancake.ts
+bun run flip
 ```
 
 ### Expected Output
@@ -463,6 +473,7 @@ Current stack: 0 pancakes
 Flipping pancake...
 Flip requested: 0x...
 
+Waiting 10s for randomness settlement window...
 Resolving randomness...
 Catching pancake...
 

--- a/docs-by-chain/evm/surge/surge-tutorial.md
+++ b/docs-by-chain/evm/surge/surge-tutorial.md
@@ -336,10 +336,10 @@ bun install
 
 ```bash
 # With sample data
-bun examples/surgeToEvmConversion.ts
+bun run surge-convert
 
 # With custom surge data file
-SURGE_DATA_FILE=path/to/surge-data.json bun examples/surgeToEvmConversion.ts
+SURGE_DATA_FILE=path/to/surge-data.json bun run surge-convert
 ```
 
 ### Expected Output


### PR DESCRIPTION
## Summary
- align the Monad EVM docs with the verified price-feed and randomness flows in sb-on-demand-examples
- update the EVM price-feeds tutorial to match the current deploy and runner layout
- update the randomness tutorial to match the current script names and settlement flow
- refresh Hyperliquid and Surge EVM pages so their commands match the current examples repo structure

## Testing
- not run (documentation update)
- commands and env vars were checked against the updated examples repo and the verified Monad testnet runs