### PR TITLE
Docs: align SDK version docs with upgraded examples

### DIFF
--- a/docs-by-chain/sui/surge/surge-tutorial.md
+++ b/docs-by-chain/sui/surge/surge-tutorial.md
@@ -65,7 +65,7 @@ import {
 } from '@switchboard-xyz/sui-sdk';
 import { fromB64 } from '@mysten/bcs';
 import { Ed25519Keypair } from '@mysten/sui/keypairs/ed25519';
-import { Keypair as SolanaKeypair } from '@solana/web3.js';
+import { Connection, Keypair as SolanaKeypair } from '@solana/web3.js';
 import * as path from 'path';
 import * as os from 'os';
 import * as fs from 'fs';
@@ -74,6 +74,7 @@ import { Transaction } from '@mysten/sui/transactions';
 // Initialize Sui clients
 const suiClient = new SuiClient({ url: 'https://fullnode.mainnet.sui.io:443' });
 const switchboardClient = new SwitchboardClient(suiClient);
+const solanaConnection = new Connection('https://api.mainnet-beta.solana.com');
 
 // Oracle mapping cache
 const oracleMapping = new Map<string, string>();
@@ -221,7 +222,7 @@ if (!solanaKeypair) {
 
   // Initialize Surge with Solana keypair (subscription owner)
   const surge = new sb.Surge({
-    connection: suiClient,
+    connection: solanaConnection,
     keypair: solanaKeypair!,
     signatureScheme: 'ed25519',
   });
@@ -269,15 +270,16 @@ if (!solanaKeypair) {
 ```typescript
 const suiClient = new SuiClient({ url: 'https://fullnode.mainnet.sui.io:443' });
 const switchboardClient = new SwitchboardClient(suiClient);
+const solanaConnection = new Connection('https://api.mainnet-beta.solana.com');
 ```
 
-Initialize the Sui and Switchboard clients. For testnet, use `https://fullnode.testnet.sui.io:443`.
+Initialize the Sui client you will submit transactions through, plus a Solana RPC connection for Surge authentication. For Sui testnet, use `https://fullnode.testnet.sui.io:443`.
 
 #### Creating Surge Connection
 
 ```typescript
 const surge = new sb.Surge({
-  connection: suiClient,
+  connection: solanaConnection,
   keypair: solanaKeypair!,
   signatureScheme: 'ed25519',
 });
@@ -285,7 +287,7 @@ const surge = new sb.Surge({
 await surge.connectAndSubscribe([{ symbol: 'BTC/USD' }]);
 ```
 
-- `connection`: Your SuiClient instance
+- `connection`: Your Solana `Connection` instance
 - `keypair`: Your Solana keypair (must have an active Surge subscription)
 - `signatureScheme`: Use `'ed25519'` for Solana keypairs
 - `connectAndSubscribe()`: Connects and subscribes to specified feeds
@@ -332,9 +334,10 @@ The mainnet and testnet examples are nearly identical with these differences:
 ```typescript
 // Testnet setup
 const suiClient = new SuiClient({ url: 'https://fullnode.testnet.sui.io:443' });
+const solanaConnection = new Connection('https://api.mainnet-beta.solana.com');
 
 const surge = new sb.Surge({
-  connection: suiClient,
+  connection: solanaConnection,
   keypair: solanaKeypair!,
   signatureScheme: 'ed25519',
 });
@@ -405,12 +408,14 @@ import * as sb from '@switchboard-xyz/on-demand';
 import { SuiClient } from '@mysten/sui/client';
 import { SwitchboardClient, emitSurgeQuote } from '@switchboard-xyz/sui-sdk';
 import { Transaction } from '@mysten/sui/transactions';
+import { Connection } from '@solana/web3.js';
 
 const suiClient = new SuiClient({ url: 'https://fullnode.mainnet.sui.io:443' });
 const switchboardClient = new SwitchboardClient(suiClient);
+const solanaConnection = new Connection('https://api.mainnet-beta.solana.com');
 
 const surge = new sb.Surge({
-  connection: suiClient,
+  connection: solanaConnection,
   keypair: solanaKeypair, // Solana keypair with active Surge subscription
   signatureScheme: 'ed25519',
 });

--- a/tooling/sdk-version-matrix.md
+++ b/tooling/sdk-version-matrix.md
@@ -1,36 +1,49 @@
 # SDK Version Matrix
 
-This page is the canonical version reference for Switchboard docs and skills.
+This page is the version reference for Switchboard docs, examples, and verifier tooling.
 
-- Baseline date: **March 3, 2026**
+- Baseline date: **March 24, 2026**
 - Source of truth: [`tooling/sdk-versions.lock.json`](sdk-versions.lock.json)
-- Verification scripts:
-  - `./scripts/check-switchboard-dep-drift.sh`
-  - `./scripts/verify-switchboard-deps.sh --full`
+- The lock file now tracks two different views:
+  - `sdk_versions` / `companion_versions`: the **canonical verifier pin set** used by local audit scripts
+  - `observed_example_versions`: the **exact versions currently pinned in the checked-in `sb-on-demand-examples` manifests**
 
-## Switchboard SDKs
+## Observed Versions In Current Examples
 
-| Package / Crate | Exact Version | Verification Reference | Notes |
+| Package / Crate | Observed Version(s) | Current Example References | Notes |
 | --- | --- | --- | --- |
-| `@switchboard-xyz/on-demand` | `3.9.0` | `solana/surge`, `solana/x402`, `sui/surge/basic` | Solana/Surge client SDK |
-| `@switchboard-xyz/common` | `5.7.0` | `evm/*`, TS smoke projects | Crossbar client + shared helpers |
-| `@switchboard-xyz/on-demand-solidity` | `1.1.0` | `evm/price-feeds`, `evm/randomness/*` | Solidity interfaces/types |
-| `@switchboard-xyz/sui-sdk` | `0.1.14` | `sui/feeds/basic`, `sui/surge/basic` | Sui quote utilities |
-| `@switchboard-xyz/aptos-sdk` | `0.1.5` | `/tmp/sb-sdk-smoke/aptos` | Aptos client SDK |
-| `@switchboard-xyz/iota-sdk` | `0.0.3` | `/tmp/sb-sdk-smoke/iota` | Iota client SDK |
-| `switchboard-on-demand` | `0.11.3` | `common/rust-feed-creation`, `solana/feeds/basic`, `solana/randomness/coin-flip` | Rust crate |
-| `switchboard-protos` | `0.2.4` | Solana program builds + host checks | Rust protobuf types |
+| `@switchboard-xyz/on-demand` | `^3.9.0` | `common`, `solana/feeds/*`, `solana/prediction-market`, `solana/randomness/coin-flip`, `solana/surge`, `solana/x402`, `sui/feeds/basic`, `sui/surge/basic` | Current TypeScript examples are aligned. |
+| `@switchboard-xyz/common` | `^5.7.0` | `common`, `common/twitter-follower-count`, `evm/*`, `solana/feeds/*`, `solana/prediction-market`, `solana/randomness/coin-flip`, `solana/surge`, `solana/x402` | Current TypeScript examples are aligned. |
+| `@switchboard-xyz/on-demand-solidity` | `^0.0.4`, `^1.1.0` | `evm/price-feeds`, `evm/randomness/*` | Price-feeds and randomness are on different package generations. |
+| `@switchboard-xyz/sui-sdk` | `^0.1.14` | `sui/feeds/basic`, `sui/surge/basic` | Aligned across current Sui examples. |
+| `switchboard-on-demand` | `0.11.3`, `=0.10.3`, `0.10.0` | `common/rust-feed-creation`, `solana/feeds/*`, `solana/prediction-market`, `solana/randomness/coin-flip` | Rust examples are also split by flow. |
+| `switchboard-protos` | `^0.2.1` | `solana/prediction-market` | Only used by the prediction-market program. |
+
+## Canonical Verifier Pin Set
+
+These are the pins currently used by `scripts/verify-switchboard-deps.sh` and related tooling when it normalizes manifests for compatibility checks.
+
+| Package / Crate | Canonical Pin | Notes |
+| --- | --- | --- |
+| `@switchboard-xyz/on-demand` | `3.9.0` | Matches the current TypeScript example set. |
+| `@switchboard-xyz/common` | `5.7.0` | Matches the current shared EVM and Solana TypeScript examples. |
+| `@switchboard-xyz/on-demand-solidity` | `1.1.0` | Canonical Solidity interface pin for verifier runs. |
+| `@switchboard-xyz/sui-sdk` | `0.1.14` | Matches current Sui examples. |
+| `@switchboard-xyz/aptos-sdk` | `0.1.5` | Used in smoke projects. |
+| `@switchboard-xyz/iota-sdk` | `0.0.3` | Used in smoke projects. |
+| `switchboard-on-demand` | `0.11.3` | Verifier pin; actual Solana program manifests currently vary by example. |
+| `switchboard-protos` | `0.2.4` | Verifier pin for Rust compatibility checks. |
 
 ## Companion Dependencies
 
-| Dependency | Exact Version | Reason |
+| Dependency | Canonical Pin | Notes |
 | --- | --- | --- |
-| `@solana/web3.js` | `1.98.4` | Solana/Surge/X402 examples |
-| `@mysten/sui` | `1.38.0` | Compatible with current Sui docs/examples import surface |
-| `@aptos-labs/ts-sdk` | `6.1.0` | Aptos + Movement TS clients |
-| `@iota/iota-sdk` | `1.11.0` | Iota TS client |
-| `ethers` | `6.16.0` | EVM examples |
-| `@coral-xyz/anchor` | `0.32.1` | TS integration in Solana examples |
+| `@solana/web3.js` | `1.98.0` | Matches current Solana examples. |
+| `@mysten/sui` | `1.38.0` | Compatible with current Sui docs/examples import surface. |
+| `@aptos-labs/ts-sdk` | `6.1.0` | Aptos + Movement smoke projects. |
+| `@iota/iota-sdk` | `1.11.0` | Iota smoke projects. |
+| `ethers` | `6.13.1` | Matches the current EVM price-feeds example manifest. |
+| `@coral-xyz/anchor` | `0.31.1` | Matches the current Solana example manifests. |
 
 ## Toolchain Baseline
 
@@ -45,9 +58,10 @@ This page is the canonical version reference for Switchboard docs and skills.
 | Aptos CLI | `8.1.0` |
 | Sui CLI | `1.66.2` |
 
-## Known Verification Notes
+## Known Notes
 
-- `@mysten/sui` latest `2.x` currently breaks the import surface used in existing docs/examples, so `1.38.0` is pinned until docs/examples migrate.
-- `solana/prediction-market` may hit `edition2024` dependency parsing under `cargo build-sbf` on current Solana toolchains. The verifier records this as a warning and runs a fallback host check.
-- EVM verification prefers `bun install` but automatically falls back to `npm install` if local Bun/Node linkage causes install failures.
-- `sui/feeds/basic` currently has an upstream failing Move unit test; dependency verification uses build/typecheck as the pass gate.
+- Current TypeScript example manifests are aligned on `@switchboard-xyz/on-demand@^3.9.0` and `@switchboard-xyz/common@^5.7.0`.
+- `@mysten/sui` latest `2.x` still breaks the import surface used in current docs/examples, so `1.38.0` remains pinned.
+- `@switchboard-xyz/on-demand-solidity` is still split by flow: `evm/price-feeds` uses `^0.0.4` while the randomness examples use `^1.1.0`.
+- `solana/prediction-market` may hit `edition2024` dependency parsing under current Solana toolchains. If `cargo build-sbf` fails there, fall back to a host-side cargo check.
+- `sui/feeds/basic` defaults its checked-in `Move.toml` to testnet. Use the explicit `build:testnet`, `build:mainnet`, `deploy:testnet`, and `deploy:mainnet` scripts when documenting or verifying flows.

--- a/tooling/sdk-versions.lock.json
+++ b/tooling/sdk-versions.lock.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
-  "baseline_date": "2026-03-03",
+  "baseline_date": "2026-03-24",
   "policy": {
     "pinning": "exact",
     "scope": "current flows only (legacy excluded)",
-    "status_model": "single canonical pinned set"
+    "status_model": "single canonical verifier set + observed example pins"
   },
   "drift_exceptions": {
     "npm": {
@@ -27,12 +27,174 @@
   },
   "companion_versions": {
     "npm": {
-      "@solana/web3.js": "1.98.4",
+      "@solana/web3.js": "1.98.0",
       "@mysten/sui": "1.38.0",
       "@aptos-labs/ts-sdk": "6.1.0",
       "@iota/iota-sdk": "1.11.0",
-      "ethers": "6.16.0",
-      "@coral-xyz/anchor": "0.32.1"
+      "ethers": "6.13.1",
+      "@coral-xyz/anchor": "0.31.1"
+    }
+  },
+  "observed_example_versions": {
+    "npm": {
+      "@switchboard-xyz/on-demand": [
+        {
+          "version": "^3.9.0",
+          "references": [
+            "common",
+            "solana/feeds/basic",
+            "solana/feeds/advanced",
+            "solana/prediction-market",
+            "solana/randomness/coin-flip",
+            "solana/surge",
+            "solana/x402",
+            "sui/feeds/basic",
+            "sui/surge/basic"
+          ]
+        }
+      ],
+      "@switchboard-xyz/common": [
+        {
+          "version": "^5.7.0",
+          "references": [
+            "common",
+            "common/twitter-follower-count",
+            "evm/price-feeds",
+            "evm/randomness",
+            "evm/randomness/coin-flip",
+            "evm/randomness/pancake-stacker",
+            "solana/feeds/basic",
+            "solana/feeds/advanced",
+            "solana/prediction-market",
+            "solana/randomness/coin-flip",
+            "solana/surge",
+            "solana/x402"
+          ]
+        }
+      ],
+      "@switchboard-xyz/on-demand-solidity": [
+        {
+          "version": "^0.0.4",
+          "references": [
+            "evm/price-feeds"
+          ]
+        },
+        {
+          "version": "^1.1.0",
+          "references": [
+            "evm/randomness/coin-flip",
+            "evm/randomness/pancake-stacker"
+          ]
+        }
+      ],
+      "@switchboard-xyz/sui-sdk": [
+        {
+          "version": "^0.1.14",
+          "references": [
+            "sui/feeds/basic",
+            "sui/surge/basic"
+          ]
+        }
+      ],
+      "@mysten/sui": [
+        {
+          "version": "^1.38.0",
+          "references": [
+            "sui/feeds/basic",
+            "sui/surge/basic"
+          ]
+        }
+      ],
+      "@solana/web3.js": [
+        {
+          "version": "^1.98.0",
+          "references": [
+            "solana/feeds/basic",
+            "solana/feeds/advanced",
+            "solana/prediction-market",
+            "solana/surge",
+            "solana/x402"
+          ]
+        },
+        {
+          "version": "^1.98.2",
+          "references": [
+            "solana/randomness/coin-flip"
+          ]
+        },
+        {
+          "version": "^1.98.4",
+          "references": [
+            "sui/surge/basic"
+          ]
+        }
+      ],
+      "@coral-xyz/anchor": [
+        {
+          "version": "^0.31.1",
+          "references": [
+            "solana/feeds/basic",
+            "solana/feeds/advanced",
+            "solana/prediction-market",
+            "solana/randomness/coin-flip",
+            "solana/surge",
+            "solana/x402"
+          ]
+        }
+      ],
+      "ethers": [
+        {
+          "version": "^6.13.1",
+          "references": [
+            "evm/price-feeds"
+          ]
+        },
+        {
+          "version": "^6.15.0",
+          "references": [
+            "evm/randomness/coin-flip",
+            "evm/randomness/pancake-stacker"
+          ]
+        },
+        {
+          "version": "^6.16.0",
+          "references": [
+            "evm/randomness"
+          ]
+        }
+      ]
+    },
+    "crates": {
+      "switchboard-on-demand": [
+        {
+          "version": "0.11.3",
+          "references": [
+            "common/rust-feed-creation"
+          ]
+        },
+        {
+          "version": "=0.10.3",
+          "references": [
+            "solana/feeds/basic",
+            "solana/feeds/advanced",
+            "solana/prediction-market"
+          ]
+        },
+        {
+          "version": "0.10.0",
+          "references": [
+            "solana/randomness/coin-flip"
+          ]
+        }
+      ],
+      "switchboard-protos": [
+        {
+          "version": "^0.2.1",
+          "references": [
+            "solana/prediction-market"
+          ]
+        }
+      ]
     }
   },
   "toolchains": {
@@ -47,7 +209,7 @@
   },
   "verification": {
     "source_repo": "../sb-on-demand-examples",
-    "last_verified": "2026-03-03",
+    "last_verified": "2026-03-24",
     "commands": [
       {
         "id": "rust-common",
@@ -87,7 +249,7 @@
       {
         "id": "sui-feeds",
         "cwd": "sui/feeds/basic",
-        "command": "npm install && npm run build"
+        "command": "npm install && npm run build:testnet"
       },
       {
         "id": "sui-surge-ts",
@@ -121,7 +283,9 @@
       }
     ],
     "notes": [
+      "Current TypeScript example manifests are aligned on @switchboard-xyz/on-demand@^3.9.0 and @switchboard-xyz/common@^5.7.0; see observed_example_versions for the full per-package breakdown.",
       "@mysten/sui latest (2.x) is not yet compatible with current docs/examples imports; pinned to 1.38.0.",
+      "@switchboard-xyz/on-demand-solidity remains split across EVM flows: evm/price-feeds uses ^0.0.4 while the randomness examples use ^1.1.0.",
       "solana/prediction-market build-sbf can fail on edition2024 transitive crates under current Solana toolchain cargo; verify with fallback host cargo check if encountered.",
       "sui/feeds/basic contains an upstream failing Move unit test; treat build/typecheck as the dependency compatibility gate."
     ]


### PR DESCRIPTION
## Summary
- update the Sui Surge tutorial to match the current SDK usage and show `sb.Surge` with a Solana `Connection`
- refresh the SDK version matrix for the newly upgraded example manifests
- update the internal SDK lockfile/source-of-truth to `@switchboard-xyz/on-demand@3.9.0` and `@switchboard-xyz/common@5.7.0`

## Validation
- searched the docs and version-source files for stale `3.7.3`, `5.5.1`, and `connection: suiClient` patterns
- `jq . tooling/sdk-versions.lock.json >/dev/null`
- `git diff --check`

## Notes
- I opened this from a clean branch off `main` because the local `jack/ai-improvements` worktree still has unrelated in-progress doc changes.
