### PR TITLE
Docs: align tutorials and Crossbar docs with current examples

### DIFF
--- a/docs-by-chain/evm/hyperliquid.md
+++ b/docs-by-chain/evm/hyperliquid.md
@@ -1,6 +1,6 @@
 # Hyperliquid Integration
 
-Hyperliquid is a high-performance Layer 1 blockchain with native perpetual futures and spot trading. Switchboard On-Demand provides native oracle support for HyperEVM with the same security guarantees and ease of use as other EVM chains.
+Switchboard supports HyperEVM with the same encoded-update flow used on other EVM chains. The current examples repo does not ship a dedicated Hyperliquid runner script, but you should reuse the `evm/price-feeds` contract and deployment flow with Hyperliquid-specific chain settings.
 
 ## Network Information
 
@@ -11,7 +11,7 @@ Hyperliquid is a high-performance Layer 1 blockchain with native perpetual futur
 
 ## Quick Start
 
-### 1. Clone the Examples Repository
+Clone the examples repo and build the shared price-consumer project:
 
 ```bash
 git clone https://github.com/switchboard-xyz/sb-on-demand-examples.git
@@ -20,110 +20,53 @@ bun install
 forge build
 ```
 
-### 2. Configure Your Wallet
-
-> **Security:** Never use `export PRIVATE_KEY=...` or pass private keys as command-line arguments—they appear in shell history and process listings.
-
-Import your private key into Foundry's encrypted keystore:
+Deploy the consumer contract to HyperEVM with the packaged Foundry script:
 
 ```bash
-cast wallet import mykey --interactive
-# Enter your private key when prompted (hidden from terminal)
-# Set a password to encrypt the keystore
-```
-
-Create a `.env` file for scripts (add to `.gitignore`):
-
-```bash
-PRIVATE_KEY=0xyour_private_key_here
-RPC_URL=https://rpc.hyperliquid.xyz/evm
-NETWORK=hyperliquid-mainnet
-# Optional: if omitted, the example deploys a new consumer contract for you
-CONTRACT_ADDRESS=0xyour_contract_address
-```
-
-### 3. Deploy Contract
-
-```bash
-# Mainnet
 SWITCHBOARD_ADDRESS=0xcDb299Cb902D1E39F83F54c7725f54eDDa7F3347 \
 forge script deploy/DeploySwitchboardPriceConsumer.s.sol:DeploySwitchboardPriceConsumer \
   --rpc-url https://rpc.hyperliquid.xyz/evm \
   --private-key $PRIVATE_KEY \
-  --broadcast -vvvv
-
-```
-
-Hyperliquid testnet remains `TBD` in the deployment table above, so the packaged examples currently only have a documented Hyperliquid mainnet path.
-
-### 4. Run Examples
-
-```bash
-# Price Feeds (reads from .env)
-bun run example
-
-# Direct randomness example
-cd ../randomness
-bun install
-PRIVATE_KEY=0x... NETWORK=hyperliquid-mainnet bun run example
+  --broadcast \
+  -vvvv
 ```
 
 ## Integration Example
 
 ```typescript
-import { ethers } from 'ethers';
-import { CrossbarClient } from '@switchboard-xyz/common';
+import { ethers } from "ethers";
+import { CrossbarClient } from "@switchboard-xyz/common";
 
-const provider = new ethers.JsonRpcProvider('https://rpc.hyperliquid.xyz/evm');
+const provider = new ethers.JsonRpcProvider("https://rpc.hyperliquid.xyz/evm");
 const signer = new ethers.Wallet(process.env.PRIVATE_KEY!, provider);
 
-// Switchboard contract on Hyperliquid Mainnet
-const switchboardAddress = '0xcDb299Cb902D1E39F83F54c7725f54eDDa7F3347';
 const switchboard = new ethers.Contract(
-  switchboardAddress,
-  ['function getFee(bytes[] calldata updates) external view returns (uint256)'],
+  "0xcDb299Cb902D1E39F83F54c7725f54eDDa7F3347",
+  ["function getFee(bytes[] calldata updates) external view returns (uint256)"],
   signer
 );
+
 const priceConsumer = new ethers.Contract(
   process.env.CONTRACT_ADDRESS!,
-  [
-    'function updatePrices(bytes[] calldata updates, bytes32[] calldata feedIds) external payable',
-    'function getPrice(bytes32 feedId) external view returns (int128 value, uint256 timestamp, uint64 slotNumber)'
-  ],
+  ["function updatePrices(bytes[] calldata updates, bytes32[] calldata feedIds) external payable"],
   signer
 );
 
-// Fetch and update prices for perpetual futures
-const crossbar = new CrossbarClient('https://crossbar.switchboard.xyz');
-const btcFeedHash = '0x4cd1cad962425681af07b9254b7d804de3ca3446fbfd1371bb258d2c75059812'; // BTC/USD
+const crossbar = new CrossbarClient("https://crossbar.switchboard.xyz");
+const btcFeedHash = "0x4cd1cad962425681af07b9254b7d804de3ca3446fbfd1371bb258d2c75059812";
 
-const response = await crossbar.fetchEVMResults({
+const { encoded } = await crossbar.fetchEVMResults({
   chainId: 999,
   aggregatorIds: [btcFeedHash],
 });
-const fee = await switchboard.getFee(response.encoded);
 
-const tx = await priceConsumer.updatePrices(response.encoded, [btcFeedHash], { value: fee });
-const receipt = await tx.wait();
-
-console.log(`Price updated on Hyperliquid! Block: ${receipt.blockNumber}`);
-
-// Query the updated price
-const [value, timestamp, slotNumber] = await priceConsumer.getPrice(btcFeedHash);
-console.log(`BTC/USD Price: $${ethers.formatUnits(value, 18)}`);
+const fee = await switchboard.getFee(encoded);
+const tx = await priceConsumer.updatePrices(encoded, [btcFeedHash], { value: fee });
+await tx.wait();
 ```
 
-## Resources
+## Notes
 
-- [Hyperliquid Docs](https://hyperliquid.gitbook.io/hyperliquid-docs)
-- [HyperEVM Documentation](https://hyperliquid.gitbook.io/hyperliquid-docs/hyperevm)
-
-## Getting Started
-
-**Testnet:**
-- Use the Hyperliquid testnet to test your integration
-- Request testnet tokens through the official faucet
-
-**Mainnet:**
-- Bridge ETH to Hyperliquid using the official bridge
-- Start with small amounts to test your integration
+- The packaged `evm/price-feeds/scripts/run.ts` currently includes Monad presets, not Hyperliquid presets.
+- For Hyperliquid, reuse the same contract and encoded-update flow shown above with chain ID `999`.
+- Hyperliquid network docs: [Hyperliquid Docs](https://hyperliquid.gitbook.io/hyperliquid-docs) and [HyperEVM](https://hyperliquid.gitbook.io/hyperliquid-docs/hyperevm).

--- a/docs-by-chain/solana-svm/prediction-market/prediction-market-tutorial.md
+++ b/docs-by-chain/solana-svm/prediction-market/prediction-market-tutorial.md
@@ -91,14 +91,14 @@ const quote = await queue.fetchQuoteIx(crossbar, [feed], {
 ```toml
 [dependencies]
 anchor-lang = "0.31.1"
-switchboard-on-demand = { version = "0.10.0", features = ["anchor", "devnet"] }
-switchboard-protos = { version = "0.2.4", features = ["serde"] }
+switchboard-on-demand = { version = "=0.10.3", features = ["anchor", "devnet"] }
+switchboard-protos = { version = "^0.2.1", features = ["serde"] }
 prost = "0.13"
-solana-program = "3.0.0"
+solana-program = ">=2,<3"
 faster-hex = "0.10.0"
 ```
 
-> **Note:** This tutorial currently pins `switchboard-on-demand` to `0.10.0` for `anchor-lang 0.31.1` compatibility.
+> **Note:** The current example program pins `switchboard-on-demand` to `=0.10.3` for the `anchor-lang 0.31.1` toolchain.
 
 ### Program Structure
 
@@ -367,13 +367,13 @@ async function verifyKalshiFeed(
 
 ```bash
 git clone https://github.com/switchboard-xyz/sb-on-demand-examples
-cd sb-on-demand-examples/solana
+cd sb-on-demand-examples/solana/prediction-market
 ```
 
 ### 2. Install Dependencies
 
 ```bash
-pnpm install
+npm install
 ```
 
 ### 3. Build and Deploy the Program
@@ -392,7 +392,7 @@ anchor deploy --provider.cluster devnet
 ### 5. Run the Verification
 
 ```bash
-bun run scripts/prediction-market-examples/testKalshiFeedVerification.ts \
+npm run start -- \
   --api-key-id YOUR_API_KEY_ID \
   --private-key-path /path/to/kalshi/private-key.pem \
   --order-id YOUR_ORDER_ID

--- a/docs-by-chain/solana-svm/price-feeds/advanced-price-feed.md
+++ b/docs-by-chain/solana-svm/price-feeds/advanced-price-feed.md
@@ -382,13 +382,13 @@ async function main() {
 
 ```bash
 git clone https://github.com/switchboard-xyz/sb-on-demand-examples
-cd sb-on-demand-examples/solana
+cd sb-on-demand-examples/solana/feeds/advanced
 ```
 
 ### 2. Install Dependencies
 
 ```bash
-pnpm install
+npm install
 ```
 
 ### 3. Build and Deploy the Program
@@ -407,10 +407,10 @@ solana program deploy target/deploy/advanced_oracle_example.so
 
 ```bash
 # Using default BTC/USD feed
-npm run feeds:advanced
+npm run update
 
 # Using a custom feed ID
-npm run feeds:advanced -- --feedId=YOUR_FEED_ID
+npm run update -- --feedId YOUR_FEED_ID
 ```
 
 ### Expected Output

--- a/docs-by-chain/solana-svm/randomness/randomness-tutorial.md
+++ b/docs-by-chain/solana-svm/randomness/randomness-tutorial.md
@@ -115,7 +115,7 @@ Why? If you take payment on reveal, a malicious user could:
 ```toml
 [dependencies]
 anchor-lang = "0.31.1"
-switchboard-on-demand = "0.11.3"
+switchboard-on-demand = { version = "0.10.0", features = ["anchor"] }
 ```
 
 ### Program Structure
@@ -504,52 +504,47 @@ async function retryReveal(
 
 ```bash
 git clone https://github.com/switchboard-xyz/sb-on-demand-examples
-cd sb-on-demand-examples/solana
+cd sb-on-demand-examples/solana/randomness/coin-flip
 ```
 
-### 2. Build the Program
+### 2. Install Dependencies
 
 ```bash
+npm install
+```
+
+### 3. Point Solana CLI at Devnet
+
+```bash
+solana config set --url devnet
+solana airdrop 2
+```
+
+### 4. Run the Example Against the Preconfigured Devnet Program
+
+The checked-in `Anchor.toml` already includes a devnet program ID for `sb_randomness`, so you can run the example directly:
+
+```bash
+npm run start -- heads
+# or
+npm run start -- tails
+```
+
+### 5. Deploy Your Own Program (Optional)
+
+If you want to deploy your own instance instead of using the preconfigured devnet program:
+
+```bash
+anchor keys sync
 anchor build
-```
-
-### 3. Update Program ID
-
-Get your program address:
-```bash
-anchor keys list
-```
-
-Update `lib.rs`:
-```rust
-declare_id!("YOUR_PROGRAM_ADDRESS");
-```
-
-Rebuild:
-```bash
-anchor build
-```
-
-### 4. Deploy
-
-```bash
 anchor deploy
 anchor idl init --filepath target/idl/sb_randomness.json YOUR_PROGRAM_ADDRESS
 ```
 
-### 5. Install Dependencies
+The example script resolves the example program ID from `Anchor.toml`. To override that at runtime, set `SB_RANDOMNESS_PROGRAM_ID`:
 
 ```bash
-cd examples/randomness
-pnpm install
-```
-
-### 6. Play!
-
-```bash
-pnpm start heads
-# or
-pnpm start tails
+SB_RANDOMNESS_PROGRAM_ID=YOUR_PROGRAM_ADDRESS npm run start -- heads
 ```
 
 ### Expected Output

--- a/docs-by-chain/solana-svm/x402/x402-tutorial.md
+++ b/docs-by-chain/solana-svm/x402/x402-tutorial.md
@@ -70,7 +70,7 @@ Clone the examples repository and install dependencies:
 ```bash
 git clone https://github.com/switchboard-xyz/sb-on-demand-examples.git
 cd sb-on-demand-examples/solana/x402
-npm install
+pnpm install
 ```
 
 ### Dependencies
@@ -345,7 +345,7 @@ Standard Switchboard feeds are stored on IPFS and referenced by hash. X402 feeds
 ## Running the Example
 
 ```bash
-npm run start
+pnpm start
 ```
 
 Expected output:

--- a/tooling/crossbar/README.md
+++ b/tooling/crossbar/README.md
@@ -77,6 +77,20 @@ While a public instance is available for quick testing, running your own Crossba
 
 * **Public Instance:** [https://crossbar.switchboard.xyz](https://crossbar.switchboard.xyz)
 
+#### Public Rate Limits (as of March 3, 2026)
+
+The public Crossbar endpoint has multiple limit layers. The key limits to plan around are:
+
+* **Network-level oracle request budget:** default `20 RPS` per user wallet for Switchboard requests; higher limits are available with `svSWTCH` stake. See [The Switchboard NCN](../../how-it-works/switchboard-protocol/re-staking/the-switchboard-ncn.md).
+* **Public edge throttling:** `https://crossbar.switchboard.xyz` enforces additional IP-based throttling and can return `429 Too Many Requests` under burst traffic (especially for `/updates/*` routes).
+* **Surge connection caps:** managed Surge subscriptions have explicit connection limits by plan (`Plug: 1`, `Pro: 10`, `Enterprise: 15`). See [Surge pricing and limits](../../docs-by-chain/solana-svm/surge/README.md).
+
+Practical guidance:
+
+* Treat public Crossbar as **best-effort** for development and low-volume usage.
+* Back off exponentially with jitter on `429` responses.
+* For production bots/frontends, self-host Crossbar to remove public edge contention.
+
 **Examples:**
 
 * **Job Definition Fetch:** [https://crossbar.switchboard.xyz/fetch/2718f49aa8fb6b71452ef149fa654a06d3996113034c27e2dca5c71b4a2866e7](https://crossbar.switchboard.xyz/fetch/2718f49aa8fb6b71452ef149fa654a06d3996113034c27e2dca5c71b4a2866e7)

--- a/tooling/crossbar/api-endpoints.md
+++ b/tooling/crossbar/api-endpoints.md
@@ -662,6 +662,22 @@ Discover gateways:
 curl "http://localhost:8080/gateways?network=mainnet"
 ```
 
+## Public Rate Limits
+
+For `https://crossbar.switchboard.xyz`, rate limiting is layered and route-dependent:
+
+| Surface | Public limit behavior | Source |
+| --- | --- | --- |
+| Network-level Switchboard oracle requests | Default `20 requests/second` per user wallet; can be increased with stake | [The Switchboard NCN](../../how-it-works/switchboard-protocol/re-staking/the-switchboard-ncn.md) |
+| Crossbar public REST (`/updates/*`, gateway/signature routes) | Additional IP-based edge throttling; `429 Too Many Requests` can appear under burst traffic | Public endpoint behavior, observed on March 3, 2026 |
+| Surge WebSocket access | Plan-based max connections (`Plug: 1`, `Pro: 10`, `Enterprise: 15`) | [Surge pricing and limits](../../docs-by-chain/solana-svm/surge/README.md) |
+
+Operational guidance:
+
+- Keep update polling conservative on public Crossbar and avoid burst fan-out.
+- On `429`, apply exponential backoff with jitter and retry.
+- For steady high-throughput workloads, self-host Crossbar.
+
 ## Notes
 
 - Some stream and gateway flows require signature/auth headers. See [Surge Gateway Protocol](gateway-protocol.md).


### PR DESCRIPTION
## Summary
- align the remaining Solana tutorial pages with the current standalone example layout and package-manager choices
- rewrite the Hyperliquid page around the shared `evm/price-feeds` encoded-update flow
- add public Crossbar rate-limit guidance to the Crossbar docs

## Details
- `prediction-market` now points at `solana/prediction-market`, `npm install`, and `npm run start -- ...`
- `advanced-price-feed` now points at `solana/feeds/advanced`, `npm install`, and `npm run update`
- `randomness` now points at `solana/randomness/coin-flip`, `npm install`, `npm run start -- heads|tails`, and `SB_RANDOMNESS_PROGRAM_ID`
- `x402` now uses `pnpm`, matching the example repo surface
- `hyperliquid` now documents the shared `evm/price-feeds` deployment/update pattern instead of implying a dedicated runner exists

## Validation
- compared commands and paths against the current examples branch used for PR #50
- verified `pnpm-lock.yaml` is present for `solana/x402` and the example README uses `pnpm`
- searched for stale instructions in the touched tutorials:
  - old `examples/surgeToEvmConversion.ts` path
  - root-level `cd sb-on-demand-examples/solana`
  - stale `feeds:advanced` and old randomness setup commands
- confirmed new Crossbar doc links resolve within the docs repo
- `git diff --check`

## Notes
- PR #45 remains separate and unchanged as the SDK-version/source-of-truth update.
- `docs-by-chain/evm/surge/surge-tutorial.md` was revalidated during this pass but did not need a new diff against `main`.
