### PR TITLE
Align EVM custom feed docs with v2 Crossbar flow

### DIFF
--- a/ai-agents-llms/skills/switchboard-crossbar-ops.md
+++ b/ai-agents-llms/skills/switchboard-crossbar-ops.md
@@ -1,7 +1,7 @@
 ---
 name: switchboard-crossbar-ops
-version: 1.0.3
-updated: 2026-02-19
+version: 1.0.4
+updated: 2026-03-25
 depends_on:
   - switchboard
 ---
@@ -14,6 +14,7 @@ Operate and use Crossbar for:
 
 - Simulating feeds (QA before deployment)
 - Storing/pinning feed definitions and obtaining a `feedId`
+- Running the v2 feed-hash flow for current EVM custom feeds
 - Fetching chain-specific update payloads (instructions/bytes)
 - Running reliable high-throughput bot and UI backends
 
@@ -70,25 +71,40 @@ Common defaults:
 - Simulate feeds → obtain sample values/errors for QA
 - Fetch update payloads:
   - Solana: instruction bundles
-  - EVM: `bytes[]` updates
+  - EVM custom feeds / Feed Builder: v2 `encoded` payload wrapped into `bytes[]`
+  - EVM legacy aggregators: `bytes[]` updates from `/updates/evm/...`
   - Randomness: encoded settlement payloads (chain-specific)
 
-### 4) REST endpoint quick reference
+### 4) EVM route selection
+
+- Feed Builder/custom feed on EVM:
+  - `GET /v2/fetch/{feed_id}`
+  - `GET /v2/simulate/{feedHashes}`
+  - `GET /v2/update/{feedHashes}?chain=evm&network=mainnet|testnet&use_timestamp=true`
+- Legacy aggregator-based EVM integration:
+  - `GET /simulate/evm/{network}/{aggregator_ids}`
+  - `GET /updates/evm/{chainId}/{aggregatorIds}`
+- Do not send a Feed Builder `bytes32` feed ID to `/updates/evm/...` as the default path. Use the v2 route first.
+
+### 5) REST endpoint quick reference
 
 | Endpoint | Method | Description | Example |
 | --- | --- | --- | --- |
 | `/store` | `POST` | Store a v1 feed definition | `curl -X POST "$CROSSBAR/store" -d '{"queue":"...","jobs":[...]}'` |
 | `/fetch/{hash}` | `GET` | Fetch a stored v1 feed definition | `curl "$CROSSBAR/fetch/$FEED_HASH"` |
+| `/v2/fetch/{feed_id}` | `GET` | Fetch a stored v2 feed definition | `curl "$CROSSBAR/v2/fetch/$FEED_ID"` |
 | `/simulate/jobs` | `POST` | Simulate raw `OracleJob[]` from request body | `curl -X POST "$CROSSBAR/simulate/jobs" -d '{"jobs":[...]}'` |
 | `/simulate/{feedHashes}` | `GET` | Simulate one or more stored feed hashes | `curl "$CROSSBAR/simulate/$FEED_HASH"` |
+| `/v2/simulate/{feedHashes}` | `GET` | Simulate one or more v2 feed hashes | `curl "$CROSSBAR/v2/simulate/$FEED_ID?network=testnet"` |
+| `/v2/update/{feedHashes}` | `GET` | Build v2 chain-specific update payloads | `curl "$CROSSBAR/v2/update/$FEED_ID?chain=evm&network=testnet&use_timestamp=true"` |
 | `/updates/solana/{network}/{feedPubkeys}` | `GET` | Build Solana pull update instructions | `curl "$CROSSBAR/updates/solana/devnet/$FEED_PUBKEY?payer=$PAYER"` |
-| `/updates/evm/{chainId}/{aggregatorIds}` | `GET` | Build EVM encoded update bytes | `curl "$CROSSBAR/updates/evm/1116/$FEED_ID"` |
+| `/updates/evm/{chainId}/{aggregatorIds}` | `GET` | Build legacy EVM encoded update bytes | `curl "$CROSSBAR/updates/evm/1116/$AGGREGATOR_ID"` |
 | `/updates/aptos/{network}/{aggregatorAddresses}` | `GET` | Build Aptos update payloads | `curl "$CROSSBAR/updates/aptos/testnet/$AGGREGATOR_ID"` |
 | `/updates/sui/{network}/{aggregatorAddresses}` | `GET` | Build Sui update payloads | `curl "$CROSSBAR/updates/sui/mainnet/$AGGREGATOR_ID"` |
 | `/updates/iota/{network}/{aggregatorAddresses}` | `GET` | Build Iota update payloads | `curl "$CROSSBAR/updates/iota/mainnet/$AGGREGATOR_ID"` |
 | `/randomness/evm` | `POST` | Fetch EVM randomness settlement payload | `curl -X POST "$CROSSBAR/randomness/evm" -d '{...}'` |
 
-### 5) Payload snapshots
+### 6) Payload snapshots
 
 `POST /simulate/jobs` request:
 
@@ -115,7 +131,28 @@ Common defaults:
 }
 ~~~
 
-`GET /updates/evm/{chainId}/{aggregatorIds}` response:
+`GET /v2/update/{feedHashes}?chain=evm&network=testnet&use_timestamp=true` response:
+
+~~~json
+{
+  "medianResponses": [
+    {
+      "value": "123450000000000000000",
+      "feedHash": "0xfd2b067707a96e5b67a7500e56706a39193f956a02e9c0a744bf212b19c7246c",
+      "numOracles": 3
+    }
+  ],
+  "oracleResponses": [],
+  "timestamp": 1730000000,
+  "slot": 0,
+  "recentHash": "0xabc123...",
+  "encoded": "0x8f6f2b7c..."
+}
+~~~
+
+For EVM consumers, wrap `encoded` into a one-element `bytes[]` when calling `getFee` or `updateFeeds`.
+
+`GET /updates/evm/{chainId}/{aggregatorIds}` legacy response:
 
 ~~~json
 {
@@ -131,24 +168,30 @@ Common defaults:
 }
 ~~~
 
-### 6) Operational guardrails
+### 7) Operational guardrails
 
 - Do not log full `.env`.
 - Treat Crossbar as sensitive infra (rate limits, credentials, API keys).
 - Use caching appropriately; monitor error rates and response latency.
+- For Monad and current custom-feed integrations, prefer the v2 feed-hash flow even if legacy EVM routes are still available.
 
 ## Minimal Example
 
 ~~~bash
 CROSSBAR="https://crossbar.switchboard.xyz"
+FEED_ID="0x4cd1cad962425681af07b9254b7d804de3ca3446fbfd1371bb258d2c75059812"
+AGGREGATOR_ID="0xfd2b067707a96e5b67a7500e56706a39193f956a02e9c0a744bf212b19c7246c"
 
 # Simulate a direct OracleJob payload
 curl -s -X POST "$CROSSBAR/simulate/jobs" \
   -H "content-type: application/json" \
   -d '{"jobs":[{"tasks":[{"valueTask":{"value":42}}]}]}' | jq .
 
-# Fetch EVM encoded update bytes for one feed
-curl -s "$CROSSBAR/updates/evm/1116/0xfd2b067707a96e5b67a7500e56706a39193f956a02e9c0a744bf212b19c7246c" | jq .
+# Fetch a Monad-compatible v2 EVM payload for one feed
+curl -s "$CROSSBAR/v2/update/$FEED_ID?chain=evm&network=testnet&use_timestamp=true" | jq .
+
+# Legacy EVM aggregator route, only for older integrations
+curl -s "$CROSSBAR/updates/evm/1116/$AGGREGATOR_ID" | jq .
 ~~~
 
 ## Troubleshooting Checklist
@@ -156,6 +199,8 @@ curl -s "$CROSSBAR/updates/evm/1116/0xfd2b067707a96e5b67a7500e56706a39193f956a02
 - IPFS store fails → verify IPFS credentials and outbound access
 - simulation intermittent errors → endpoints unstable; add source diversity/fallbacks
 - update fetch fails → network mismatch, RPC unreachable, queue mismatch
+- `ORACLE_UNAVAILABLE` on `/v2/update` after successful `/v2/fetch` and `/v2/simulate` → treat as managed oracle/gateway availability, not a missing permission
+- EVM custom feed not resolving → confirm you are using `/v2/fetch`, `/v2/simulate`, and `/v2/update`, not the legacy aggregator route
 - rate limits → self-host + caching + reduce polling
 
 ## References

--- a/ai-agents-llms/skills/switchboard-evm-feeds.md
+++ b/ai-agents-llms/skills/switchboard-evm-feeds.md
@@ -75,12 +75,18 @@ import { CrossbarClient } from "@switchboard-xyz/common";
 const crossbarUrl = process.env.CROSSBAR_URL ?? "https://crossbar.switchboard.xyz";
 const crossbar = new CrossbarClient(crossbarUrl);
 
-// Method naming differs across SDK versions.
-// Treat the result as `updates: bytes[]` suitable for `updateFeeds`.
-const { encoded: updates } = await crossbar.fetchEVMResults({
-  chainId,
-  aggregatorIds: [feedId],
+// For Feed Builder/custom feeds, use the v2 feed-hash flow.
+await crossbar.simulateFeed(feedId, false, undefined, network);
+
+const response = await crossbar.fetchV2Update([feedId], {
+  chain: "evm",
+  network,
+  use_timestamp: true,
 });
+
+if (!response.encoded) throw new Error("Crossbar returned no encoded update payload");
+
+const updates = [response.encoded];
 ~~~
 
 ### 3) Contract-side recommended pattern (atomic update+use)
@@ -127,7 +133,17 @@ Crank loop:
 
 ~~~ts
 async function crankOnce(feedIds: string[]) {
-  const { updates } = await crossbar.fetchEvmUpdates({ chainId, feedIds });
+  const response = await crossbar.fetchV2Update(feedIds, {
+    chain: "evm",
+    network,
+    use_timestamp: true,
+  });
+
+  if (!response.encoded) {
+    throw new Error("Crossbar returned no encoded update payload");
+  }
+
+  const updates = [response.encoded];
 
   const fee = await switchboard.getFee(updates);
   const tx = await switchboard.updateFeeds(updates, { value: fee });
@@ -158,6 +174,8 @@ Produce an `EvmFeedIntegrationPlan` including:
 - Fee too low → always call `getFee(updates)` and set `msg.value`
 - Stale timestamp → fetch fresh updates; raise max age only for non-critical paths
 - Wrong feed/network → verify feedId and deployment match chainId/network
+- Feed Builder custom feed on EVM → use `simulateFeed(...)` and `fetchV2Update(...)`, not `fetchEVMResults(...)`
+- `ORACLE_UNAVAILABLE` after successful simulation → treat as managed oracle/gateway availability, not a missing permission
 
 ## References
 

--- a/custom-feeds/build-and-deploy-feed/deploy-feed.md
+++ b/custom-feeds/build-and-deploy-feed/deploy-feed.md
@@ -198,18 +198,41 @@ contract Example {
 Use Crossbar to fetch oracle-signed updates (encoded) for submission:
 
 ```ts
-import * as ethers from "ethers";
-import { CrossbarClient } from "@switchboard-xyz/on-demand";
+import { CrossbarClient } from "@switchboard-xyz/common";
+
+const feedId = "0x...your_feed_id...";
+const crossbarNetwork = "testnet"; // or "mainnet"
 
 const crossbar = new CrossbarClient("https://crossbar.switchboard.xyz");
 
-const { encoded } = await crossbar.fetchEVMResults({
-  chainId: 421614, // example: Arbitrum Sepolia
-  aggregatorIds: ["0x...your_feed_id..."],
+// Recommended preflight for Feed Builder feeds:
+await crossbar.fetchOracleFeed(feedId);
+await crossbar.simulateFeed(feedId, false, undefined, crossbarNetwork);
+
+const response = await crossbar.fetchV2Update([feedId], {
+  chain: "evm",
+  network: crossbarNetwork,
+  use_timestamp: true,
 });
 
-// submit `encoded` to your contract method that calls updateFeeds(...)
+if (!response.encoded) {
+  throw new Error("Crossbar returned no encoded update payload");
+}
+
+const updates = [response.encoded];
+
+// submit `updates` to your contract method that calls updateFeeds(...)
 ```
+
+Recommended EVM preflight order for custom feeds:
+
+1. `GET /v2/fetch/{feedId}` or `crossbar.fetchOracleFeed(feedId)` to confirm the definition exists
+2. `GET /v2/simulate/{feedId}?network=testnet|mainnet` or `crossbar.simulateFeed(...)` to confirm the jobs resolve
+3. `GET /v2/update/{feedId}?chain=evm&network=testnet|mainnet&use_timestamp=true` or `crossbar.fetchV2Update(...)` to obtain the EVM payload
+
+Use the same deterministic `feedId` / feed hash from Feed Builder or Explorer for all three steps.
+
+> Do not pass a Feed Builder `bytes32` feed ID into `fetchEVMResults()` or `simulateEVMFeeds()` unless you are intentionally using the legacy aggregator-based EVM flow.
 
 ---
 
@@ -221,4 +244,3 @@ If you’re targeting a non-Solana chain, treat “deployment” as:
 
 1. Create/publish a feed definition and get its feed ID/address.
 2. Use the chain’s SDK to fetch and verify oracle results in your transaction flow.
-

--- a/docs-by-chain/evm/README.md
+++ b/docs-by-chain/evm/README.md
@@ -4,6 +4,14 @@ Learn how to build and use programs that call Switchboard data feeds on EVM chai
 
 If you need to create a custom data feed, check out the [custom feeds section](../../custom-feeds/build-and-deploy-feed/README.md).
 
+If you are integrating a Feed Builder feed or any `bytes32` feed ID from the explorer on EVM, use the v2 feed-hash flow:
+
+1. Fetch the definition with `/v2/fetch/{feedId}`
+2. Simulate with `/v2/simulate/{feedHashes}` or `CrossbarClient.simulateFeed(...)`
+3. Build the on-chain payload with `/v2/update/{feedHashes}?chain=evm&network=mainnet|testnet&use_timestamp=true`
+
+The legacy `/simulate/evm` and `/updates/evm` routes are only for older aggregator-based integrations.
+
 ## Monad Example Network Switch
 
 The packaged Monad examples in `sb-on-demand-examples/evm` now share one network selector:

--- a/docs-by-chain/evm/hyperliquid.md
+++ b/docs-by-chain/evm/hyperliquid.md
@@ -55,13 +55,21 @@ const priceConsumer = new ethers.Contract(
 const crossbar = new CrossbarClient("https://crossbar.switchboard.xyz");
 const btcFeedHash = "0x4cd1cad962425681af07b9254b7d804de3ca3446fbfd1371bb258d2c75059812";
 
-const { encoded } = await crossbar.fetchEVMResults({
-  chainId: 999,
-  aggregatorIds: [btcFeedHash],
+await crossbar.simulateFeed(btcFeedHash, false, undefined, "mainnet");
+
+const response = await crossbar.fetchV2Update([btcFeedHash], {
+  chain: "evm",
+  network: "mainnet",
+  use_timestamp: true,
 });
 
-const fee = await switchboard.getFee(encoded);
-const tx = await priceConsumer.updatePrices(encoded, [btcFeedHash], { value: fee });
+if (!response.encoded) {
+  throw new Error("Crossbar returned no encoded update payload");
+}
+
+const updates = [response.encoded];
+const fee = await switchboard.getFee(updates);
+const tx = await priceConsumer.updatePrices(updates, [btcFeedHash], { value: fee });
 await tx.wait();
 ```
 

--- a/docs-by-chain/evm/monad.md
+++ b/docs-by-chain/evm/monad.md
@@ -1,6 +1,6 @@
 # Monad Integration
 
-Monad is the primary EVM network exercised by the current `sb-on-demand-examples` repo. The runnable EVM examples now share a single network switch:
+Monad is the primary EVM network exercised by the current `sb-on-demand-examples` repo. The packaged EVM examples now share a single network switch:
 
 - `NETWORK=monad-testnet`
 - `NETWORK=monad-mainnet`
@@ -67,22 +67,10 @@ NETWORK=monad-mainnet bun run deploy
 NETWORK=monad-mainnet bun run example
 ```
 
-The packaged script handles the current Crossbar Monad testnet rollout by falling back to the network-agnostic oracle quote endpoint if the chain-specific feed lookup is unavailable.
-
-## Quick Start: Direct Randomness
+## Quick Start: Randomness
 
 ```bash
-cd ../randomness
-bun install
-PRIVATE_KEY=0xyour_private_key_here bun run example
-```
-
-That helper talks directly to the Switchboard proxy, creates a randomness request, waits for the settlement window, resolves through Crossbar, and settles on-chain. It also supports `hyperliquid-mainnet` in addition to Monad.
-
-## Quick Start: Coin Flip
-
-```bash
-cd coin-flip
+cd ../randomness/coin-flip
 bun install
 forge build
 cp .env.example .env
@@ -101,40 +89,6 @@ Run on mainnet:
 NETWORK=monad-mainnet bun run deploy
 NETWORK=monad-mainnet bun run flip
 ```
-
-After deployment, fund the example contract with a small bankroll so it can pay winning flips:
-
-```bash
-cast send $COIN_FLIP_CONTRACT_ADDRESS \
-  --rpc-url ${RPC_URL:-https://testnet-rpc.monad.xyz} \
-  --private-key $PRIVATE_KEY \
-  --value 0.05ether
-```
-
-## Quick Start: Pancake Stacker
-
-```bash
-cd ../pancake-stacker
-bun install
-forge build
-cp .env.example .env
-```
-
-Run on testnet:
-
-```bash
-bun run deploy
-bun run flip
-```
-
-Run on mainnet:
-
-```bash
-NETWORK=monad-mainnet bun run deploy
-NETWORK=monad-mainnet bun run flip
-```
-
-If a previous run already created a pending flip, the packaged script resumes settlement instead of failing.
 
 ## Integration Example
 
@@ -143,7 +97,7 @@ import { ethers } from "ethers";
 import { CrossbarClient } from "@switchboard-xyz/common";
 
 const networkName = process.env.NETWORK || "monad-testnet";
-const chainId = networkName === "monad-mainnet" ? 143 : 10143;
+const crossbarNetwork = networkName === "monad-mainnet" ? "mainnet" : "testnet";
 const rpcUrl =
   process.env.RPC_URL ||
   (networkName === "monad-mainnet"
@@ -171,19 +125,36 @@ const priceConsumer = new ethers.Contract(
 
 const feedHash = "0xa0950ee5ee117b2e2c30f154a69e17bfb489a7610c508dc5f67eb2a14616d8ea";
 const crossbar = new CrossbarClient("https://crossbar.switchboard.xyz");
-const { encoded } = await crossbar.fetchEVMResults({
-  chainId,
-  aggregatorIds: [feedHash],
+
+// Useful when validating a custom Feed Builder feed before sending a transaction.
+await crossbar.simulateFeed(feedHash, false, undefined, crossbarNetwork);
+
+const response = await crossbar.fetchV2Update([feedHash], {
+  chain: "evm",
+  network: crossbarNetwork,
+  use_timestamp: true,
 });
 
-const fee = await switchboard.getFee(encoded);
-const tx = await priceConsumer.updatePrices(encoded, [feedHash], { value: fee });
+if (!response.encoded) {
+  throw new Error("Crossbar returned no encoded update payload");
+}
+
+const updates = [response.encoded];
+const fee = await switchboard.getFee(updates);
+const tx = await priceConsumer.updatePrices(updates, [feedHash], { value: fee });
 await tx.wait();
 ```
 
+## Custom Feed Troubleshooting
+
+- Feed Builder custom feeds do not require a separate activation or permission toggle on Monad.
+- Use the same `bytes32` feed hash/feed ID from Feed Builder or Explorer for the full v2 flow:
+  - `GET /v2/fetch/{feedId}`
+  - `GET /v2/simulate/{feedId}?network=testnet|mainnet`
+  - `GET /v2/update/{feedId}?chain=evm&network=testnet|mainnet&use_timestamp=true`
+- If `v2/fetch` and `v2/simulate` succeed but `v2/update` returns `ORACLE_UNAVAILABLE`, the issue is managed oracle or gateway availability for that feed, not a missing deployment step or permission.
+
 ## Notes
 
-- `MON` is the native gas token on Monad.
 - Testnet MON is available from the [Monad faucet](https://faucet.monad.xyz).
-- The generic randomness helper at `evm/randomness/randomness.ts` still supports `hyperliquid-mainnet` in addition to Monad.
-- The current examples repo is organized as standalone subprojects under `evm/price-feeds`, `evm/randomness`, `evm/randomness/coin-flip`, and `evm/randomness/pancake-stacker`.
+- The generic randomness helper at `evm/randomness/randomness.ts` still supports `hyperliquid-mainnet` in addition to Monad. Run it from `evm/randomness` after `bun install`.

--- a/docs-by-chain/evm/price-feeds/price-feeds-tutorial.md
+++ b/docs-by-chain/evm/price-feeds/price-feeds-tutorial.md
@@ -37,25 +37,34 @@ This pattern ensures prices are cryptographically verified on-chain while keepin
 
 ### The CrossbarClient
 
-The `CrossbarClient` from `@switchboard-xyz/common` is your interface to fetch oracle data:
+The `CrossbarClient` from `@switchboard-xyz/common` is your interface to fetch oracle data for the v2 feed-hash flow used by current Monad integrations and Feed Builder feeds:
 
 ```typescript
 import { CrossbarClient } from "@switchboard-xyz/common";
 
 const crossbar = new CrossbarClient("https://crossbar.switchboard.xyz");
-const { encoded } = await crossbar.fetchEVMResults({
-  chainId: 999,  // Your chain ID
-  aggregatorIds: [feedId],
+const response = await crossbar.fetchV2Update([feedId], {
+  chain: "evm",
+  network: "mainnet",
+  use_timestamp: true,
 });
+
+if (!response.encoded) {
+  throw new Error("Crossbar returned no encoded update payload");
+}
+
+const updates = [response.encoded];
 ```
+
+If you are using a `bytes32` feed ID from Explorer or Feed Builder, this is the path you want. Legacy `fetchEVMResults()` and `/updates/evm/...` routes remain available for older aggregator-based integrations, but they are not the primary flow for custom feeds.
 
 ### Fee Handling
 
 Some networks require a fee for oracle updates. Always check before submitting:
 
 ```typescript
-const fee = await switchboard.getFee(encoded);
-await contract.updatePrices(encoded, { value: fee });
+const fee = await switchboard.getFee(updates);
+await contract.updatePrices(updates, [feedId], { value: fee });
 ```
 
 ## The Smart Contract
@@ -306,6 +315,7 @@ async function main() {
 
   const consumerAbi = [
     "function updatePrices(bytes[] calldata updates, bytes32[] calldata feedIds) external payable",
+    "function getPrice(bytes32 feedId) external view returns (int128 value, uint256 timestamp, uint64 slotNumber)",
     "event PriceUpdated(bytes32 indexed feedId, int128 oldPrice, int128 newPrice, uint256 timestamp, uint64 slotNumber)"
   ];
   const switchboardAbi = [
@@ -320,16 +330,26 @@ async function main() {
   const feedId = "0x4cd1cad962425681af07b9254b7d804de3ca3446fbfd1371bb258d2c75059812";
 
   // Step 1: Fetch signed oracle data from Crossbar
-  const { encoded } = await crossbar.fetchEVMResults({
-    chainId: 999,  // HyperEVM mainnet
-    aggregatorIds: [feedId],
+  const response = await crossbar.fetchV2Update([feedId], {
+    chain: "evm",
+    network: "mainnet",
+    use_timestamp: true,
   });
 
-  console.log("Fetched", encoded.length, "encoded updates");
+  if (!response.encoded) {
+    throw new Error("Crossbar returned no encoded update payload");
+  }
+
+  const updates = [response.encoded];
+  const median = response.medianResponses[0];
+
+  console.log("Fetched", updates.length, "encoded updates");
+  console.log("Median value:", median?.value);
+  console.log("Oracle timestamp:", new Date(response.timestamp * 1000).toISOString());
 
   // Step 2: Submit to your contract
-  const fee = await switchboard.getFee(encoded);
-  const tx = await contract.updatePrices(encoded, [feedId], { value: fee });
+  const fee = await switchboard.getFee(updates);
+  const tx = await contract.updatePrices(updates, [feedId], { value: fee });
   console.log("Transaction hash:", tx.hash);
 
   // Step 3: Wait for confirmation
@@ -368,22 +388,30 @@ main().catch(console.error);
 #### Step 1: Fetch Oracle Data
 
 ```typescript
-const { encoded } = await crossbar.fetchEVMResults({
-  chainId: 999,
-  aggregatorIds: [feedId],
+const response = await crossbar.fetchV2Update([feedId], {
+  chain: "evm",
+  network: "mainnet",
+  use_timestamp: true,
 });
+
+if (!response.encoded) {
+  throw new Error("Crossbar returned no encoded update payload");
+}
+
+const updates = [response.encoded];
 ```
 
-The `fetchEVMResults` call returns encoded oracle data signed by Switchboard oracles. This data includes:
-- The price value
-- Timestamp
-- Oracle signatures
+The `fetchV2Update` call returns:
+- `medianResponses` with one consensus value per feed
+- `timestamp` for the signed oracle consensus
+- `oracleResponses` for per-oracle detail
+- `encoded`, the EVM payload you wrap into `bytes[]` for `getFee` and `updateFeeds`
 
 #### Step 2: Submit to Contract
 
 ```typescript
-const fee = await switchboard.getFee(encoded);
-const tx = await contract.updatePrices(encoded, [feedId], { value: fee });
+const fee = await switchboard.getFee(updates);
+const tx = await contract.updatePrices(updates, [feedId], { value: fee });
 ```
 
 Your contract receives the encoded data, submits it to Switchboard for verification, then stores the result.
@@ -483,10 +511,16 @@ Switch to Monad mainnet without changing the script:
 NETWORK=monad-mainnet bun run example
 ```
 
+For Feed Builder or custom feeds, it is useful to preflight before sending a transaction:
+
+```typescript
+await crossbar.simulateFeed(feedId, false, undefined, "testnet");
+```
+
 ### Expected Output
 
 ```
-Aggregator ID: 0x4cd1cad962425681af07b9254b7d804de3ca3446fbfd1371bb258d2c75059812
+Feed ID: 0x4cd1cad962425681af07b9254b7d804de3ca3446fbfd1371bb258d2c75059812
 Encoded updates length: 1
 Transaction hash: 0x...
 Transaction confirmed in block: 12345678
@@ -494,7 +528,6 @@ Transaction confirmed in block: 12345678
 === Feed Update Event ===
 Price: 97234500000000000000000
 Timestamp: 2024-12-18T10:30:00.000Z
-Oracle ID: 0x...
 
 === Latest Update Details ===
 Result: 97234500000000000000000
@@ -616,6 +649,7 @@ Popular feeds include:
 | `PriceDeviationTooHigh` | Normal during high volatility; adjust `maxDeviationBps` if needed |
 | `PriceTooOld` | Fetch fresh data from Crossbar; adjust `maxPriceAge` if needed |
 | `InvalidFeedId` | Ensure the feed ID exists and has been updated at least once |
+| `ORACLE_UNAVAILABLE` | If `simulateFeed` works but `fetchV2Update` fails, treat it as oracle or gateway availability rather than a missing deployment step |
 | Build errors | Run `forge clean && forge build` |
 
 ## Next Steps

--- a/tooling/crossbar/api-endpoints.md
+++ b/tooling/crossbar/api-endpoints.md
@@ -29,6 +29,15 @@ For machine-readable schema and live testing:
 | `GET` | `/debug/cid/{hash}` | CID conversion/debug |
 | `GET` | `/debug/bnb` | Binance debug endpoint |
 
+## EVM Route Selection
+
+Use different Crossbar routes depending on whether you are integrating a current Feed Builder/custom feed or an older aggregator-based EVM integration.
+
+| Use case | Use these routes | Identifier | Notes |
+| --- | --- | --- | --- |
+| Feed Builder/custom feed on EVM | `/v2/fetch/{feed_id}`, `/v2/simulate/{feedHashes}`, `/v2/update/{feedHashes}` | deterministic `bytes32` feed ID / feed hash | Recommended flow for Monad and current custom-feed integrations. Use `chain=evm`, `network=mainnet|testnet`, and usually `use_timestamp=true` on `/v2/update`. |
+| Legacy aggregator-based EVM integration | `/simulate/evm/{network}/{aggregator_ids}`, `/updates/evm/{chainId}/{aggregatorIds}` | legacy aggregator ID | Compatibility flow for older EVM integrations. Do not use this as the primary path for Feed Builder custom feeds. |
+
 ## Simulation Endpoints
 
 ### Generic
@@ -283,6 +292,58 @@ Response (`200`):
 ```
 
 ### Updates
+
+#### `GET /v2/update/{feedHashes}`
+
+Purpose: build a chain-specific consensus payload for one or more v2 feed hashes.
+
+Path:
+
+- `feedHashes`: comma-separated deterministic feed IDs / feed hashes
+
+Query:
+
+- `chain` (`string`, required for chain-specific payloads; use `evm` for EVM)
+- `network` (`string`, optional; `mainnet` or `testnet`)
+- `use_timestamp` (`bool`, optional)
+- `num_oracles` (`u32`, optional)
+- `gateway` (`string`, optional)
+
+Response (`200`): object
+
+```json
+{
+  "medianResponses": [
+    {
+      "value": "123450000000000000000",
+      "feedHash": "0xfd2b067707a96e5b67a7500e56706a39193f956a02e9c0a744bf212b19c7246c",
+      "numOracles": 3
+    }
+  ],
+  "oracleResponses": [],
+  "timestamp": 1730000000,
+  "slot": 0,
+  "recentHash": "0xabc123...",
+  "encoded": "0x8f6f2b7c..."
+}
+```
+
+V2 update response schema:
+
+- `medianResponses`: one consensus value per requested feed hash
+- `oracleResponses`: per-oracle response detail
+- `timestamp`: signed consensus timestamp
+- `slot`: slot or sequence metadata from the gateway
+- `recentHash`: recent hash used for the signed payload
+- `encoded`: chain-specific encoded update payload
+
+For EVM, wrap `encoded` into a one-element `bytes[]` when calling `getFee` or `updateFeeds`.
+
+Monad example:
+
+```bash
+curl "http://localhost:8080/v2/update/0x4cd1cad962425681af07b9254b7d804de3ca3446fbfd1371bb258d2c75059812?chain=evm&network=testnet&use_timestamp=true"
+```
 
 #### `GET /updates/solana/{network}/{feedPubkeys}`
 
@@ -654,6 +715,12 @@ Fetch EVM updates:
 
 ```bash
 curl "http://localhost:8080/updates/evm/1116/0xfd2b067707a96e5b67a7500e56706a39193f956a02e9c0a744bf212b19c7246c"
+```
+
+Fetch a Monad custom-feed payload with the v2 route:
+
+```bash
+curl "http://localhost:8080/v2/update/0x4cd1cad962425681af07b9254b7d804de3ca3446fbfd1371bb258d2c75059812?chain=evm&network=testnet&use_timestamp=true"
 ```
 
 Discover gateways:


### PR DESCRIPTION
## Summary
- switch primary EVM custom-feed docs from legacy aggregator-style calls to the v2 feed-hash flow
- add explicit route-selection guidance for Feed Builder/custom feeds versus legacy EVM aggregators
- update the Crossbar ops and EVM feeds skills to match the docs

## What changed
- replace `fetchEVMResults(...)` examples with `simulateFeed(...)` and `fetchV2Update(...)` in the EVM/Monad/custom-feed docs
- add Monad troubleshooting for `ORACLE_UNAVAILABLE` and clarify that no extra EVM feed activation is required
- document `/v2/fetch`, `/v2/simulate`, and `/v2/update` as the canonical EVM custom-feed path

## Verification
- confirmed live Crossbar responses for `v2/fetch`, `v2/simulate`, and `v2/update` during the investigation
- searched the primary EVM/custom-feed docs to ensure legacy EVM routes are only referenced as compatibility/legacy guidance