### PR TITLE
docs: align monad evm tutorials with examples

### DIFF
--- a/docs-by-chain/evm/monad.md
+++ b/docs-by-chain/evm/monad.md
@@ -49,29 +49,40 @@ Before broadcasting transactions, the packaged scripts verify:
 git clone https://github.com/switchboard-xyz/sb-on-demand-examples.git
 cd sb-on-demand-examples/evm/price-feeds
 bun install
+(
+  cd ../randomness/coin-flip
+  [ -d lib/forge-std ] || forge install foundry-rs/forge-std --no-git --shallow
+)
 forge build
 cp .env.example .env
 ```
 
-Run on testnet:
+Fastest testnet path:
+
+```bash
+bun run example
+```
+
+If `CONTRACT_ADDRESS` is unset, `bun run example` deploys a fresh consumer before submitting the v2 update. If you want to deploy separately first:
 
 ```bash
 bun run deploy
+# Save the emitted address into CONTRACT_ADDRESS in .env, then rerun:
 bun run example
 ```
 
 Flip to mainnet with one env var:
 
 ```bash
-NETWORK=monad-mainnet bun run deploy
 NETWORK=monad-mainnet bun run example
 ```
 
-## Quick Start: Randomness
+## Quick Start: Coin Flip
 
 ```bash
 cd ../randomness/coin-flip
 bun install
+[ -d lib/forge-std ] || forge install foundry-rs/forge-std --no-git --shallow
 forge build
 cp .env.example .env
 ```
@@ -80,6 +91,20 @@ Run on testnet:
 
 ```bash
 bun run deploy
+```
+
+Save the emitted contract address into `COIN_FLIP_CONTRACT_ADDRESS`, then fund the contract bankroll before the first flip. The contract accepts any positive wager, and the packaged CLI uses `0.01 MON` by default:
+
+```bash
+cast send $COIN_FLIP_CONTRACT_ADDRESS \
+  --rpc-url ${RPC_URL:-https://testnet-rpc.monad.xyz} \
+  --private-key $PRIVATE_KEY \
+  --value 0.01ether
+```
+
+Then run the CLI flow:
+
+```bash
 bun run flip
 ```
 
@@ -87,6 +112,7 @@ Run on mainnet:
 
 ```bash
 NETWORK=monad-mainnet bun run deploy
+# Save COIN_FLIP_CONTRACT_ADDRESS in .env, fund the bankroll on mainnet, then:
 NETWORK=monad-mainnet bun run flip
 ```
 
@@ -157,4 +183,4 @@ await tx.wait();
 ## Notes
 
 - Testnet MON is available from the [Monad faucet](https://faucet.monad.xyz).
-- The generic randomness helper at `evm/randomness/randomness.ts` still supports `hyperliquid-mainnet` in addition to Monad. Run it from `evm/randomness` after `bun install`.
+- The generic randomness helper at `evm/randomness/randomness.ts` still supports `hyperliquid-mainnet` in addition to Monad. Run it from `evm/randomness` after `bun install`, `cp .env.example .env`, and `bun run example`.

--- a/docs-by-chain/evm/price-feeds/price-feeds-tutorial.md
+++ b/docs-by-chain/evm/price-feeds/price-feeds-tutorial.md
@@ -481,6 +481,10 @@ cd sb-on-demand-examples/evm/price-feeds
 
 ```bash
 bun install
+(
+  cd ../randomness/coin-flip
+  [ -d lib/forge-std ] || forge install foundry-rs/forge-std --no-git --shallow
+)
 forge build
 ```
 
@@ -500,6 +504,8 @@ CONTRACT_ADDRESS=0x...
 ```
 
 ### 4. Run the Example
+
+If `CONTRACT_ADDRESS` is unset, the script deploys a fresh consumer contract before it fetches the v2 update and submits it on-chain:
 
 ```bash
 bun run example
@@ -650,7 +656,7 @@ Popular feeds include:
 | `PriceTooOld` | Fetch fresh data from Crossbar; adjust `maxPriceAge` if needed |
 | `InvalidFeedId` | Ensure the feed ID exists and has been updated at least once |
 | `ORACLE_UNAVAILABLE` | If `simulateFeed` works but `fetchV2Update` fails, treat it as oracle or gateway availability rather than a missing deployment step |
-| Build errors | Run `forge clean && forge build` |
+| Build errors | Bootstrap `forge-std` in `../randomness/coin-flip`, then rerun `forge build` |
 
 ## Next Steps
 

--- a/docs-by-chain/evm/randomness/randomness-tutorial.md
+++ b/docs-by-chain/evm/randomness/randomness-tutorial.md
@@ -261,15 +261,10 @@ async function main() {
 ### Step 2: Request Randomness (Flip the Pancake)
 
 ```typescript
-    const [, hasPendingFlip] = await contract.getPlayerStats(wallet.address);
-
-    if (hasPendingFlip) {
-        console.log("Found pending flip, resuming settlement...");
-    } else {
-        const tx = await contract.flipPancake();
-        await tx.wait();
-        console.log("Flip requested:", tx.hash);
-    }
+    // Call flipPancake() to request randomness
+    const tx = await contract.flipPancake();
+    await tx.wait();
+    console.log("Flip requested:", tx.hash);
 ```
 
 This triggers the **Request Randomness** phase on-chain.
@@ -305,8 +300,6 @@ The contract returns:
 ```
 
 This is where **Crossbar** talks to the **Oracle** and returns the encoded randomness proof.
-
-In practice you should wait until `rollTimestamp + minSettlementDelay` before calling Crossbar. The packaged example script adds a small buffer and resumes an already-pending flip if a previous run stopped after requesting randomness.
 
 ### Step 5: Settle On-Chain (Catch the Pancake)
 
@@ -435,7 +428,8 @@ The contract gracefully handles settlement failures by catching exceptions and r
 ```bash
 git clone https://github.com/switchboard-xyz/sb-on-demand-examples
 cd sb-on-demand-examples/evm/randomness/pancake-stacker
-bun install
+bun install  # or npm install
+[ -d lib/forge-std ] || forge install foundry-rs/forge-std --no-git --shallow
 forge build
 ```
 
@@ -482,7 +476,6 @@ Current stack: 0 pancakes
 Flipping pancake...
 Flip requested: 0x...
 
-Waiting 10s for randomness settlement window...
 Resolving randomness...
 Catching pancake...
 


### PR DESCRIPTION
## Summary
- align the Monad docs with the current price-feed example bootstrap and auto-deploy behavior
- document the Coin Flip bankroll-first flow and the packaged 0.01 MON smoke-test wager
- keep the Pancake Stacker tutorial aligned with the actual example script and Foundry bootstrap step

## Notes
- this is the docs companion to the examples cleanup in `jack/evm-monad-examples-cleanup`