### PR TITLE
[codex] Prefer variable overrides in secrets docs

### DIFF
--- a/custom-feeds/build-and-deploy-feed/build-with-typescript.md
+++ b/custom-feeds/build-and-deploy-feed/build-with-typescript.md
@@ -201,7 +201,6 @@ Switchboard supports many task types, including:
 - JsonParseTask (JSONPath extraction)
 - MedianTask (sub-aggregation inside a job)
 - JupiterSwapTask (Solana DEX price simulation)
-- SecretsTask (secure secret retrieval)
 
 Full task docs:
 - https://protos.docs.switchboard.xyz/
@@ -212,16 +211,12 @@ Full task docs:
 
 ### Variable overrides (`${VAR_NAME}`)
 
-Variable overrides let you inject values at runtime.
+Use variable overrides to insert API keys and auth tokens into tasks at runtime.
+
+See [Data Feed Variable Overrides](../advanced-feed-configuration/data-feed-variable-overrides.md) for the supported pattern and the full security guidance.
 
 **Critical rule:** Only use variables for **authentication** (API keys/tokens).  
 Do **not** use variables for anything that changes feed logic (URLs, JSON paths, multipliers), because consumers cannot cryptographically verify what values were injected at runtime.
-
-### SecretsTask
-
-If you need to retrieve secrets from a dedicated secrets server at runtime, include a SecretsTask at the top of the job, then use the unwrapped variables in downstream tasks.
-
-(See `SecretsTask` docs in the task reference above.)
 
 ---
 

--- a/custom-feeds/task-types.md
+++ b/custom-feeds/task-types.md
@@ -2402,13 +2402,17 @@ _**Example**_: Returns the numerical result from the conditionalTask's subtasks,
 
 ### SecretsTask
 
-Securely request secrets from a Switchboard SecretsServer that are owned by a specific authority. Any secrets that are returned for the current feed will then be unwrapped into variables to be accessed later.
+Deprecated compatibility task for the legacy Switchboard secrets-server flow.
+
+`SecretsTask` is no longer officially supported. The hosted secrets service has been taken down, and new integrations should use `variableOverrides` to inject API keys and other authentication credentials at request time.
+
+See the Data Feed Variable Overrides guide for the supported pattern.
 
 _**Input**_: None
 
 _**Returns**_: The input
 
-_**Example**_: SecretsTask
+_**Example**_: Legacy `SecretsTask`
 
 ```json
 {
@@ -2421,7 +2425,7 @@ _**Example**_: SecretsTask
 | Field | Type | Description |
 |-------|------|-------------|
 | `authority` | string | The authority of the secrets that are to be requested. |
-| `url` | string | The url of the server to request secrets from. The default is https://api.secrets.switchboard.xyz. |
+| `url` | string | Legacy server URL override for historical or self-hosted deployments. The old hosted default at https://api.secrets.switchboard.xyz is no longer available. |
 
 ---
 


### PR DESCRIPTION
## Summary
- remove SecretsTask from the build-with-typescript reader path
- explain that runtime secrets should be passed via variableOverrides
- keep the task reference aligned by marking SecretsTask as deprecated compatibility-only guidance

## Why
The hosted secrets service is no longer available, and the public docs should point readers to the currently supported secret injection path.

## Impact
Readers following the main feed-building docs now land on variableOverrides directly instead of the legacy secrets-server flow.

## Validation
- git diff --check
- verified build-with-typescript no longer mentions SecretsTask
- reviewed task-types to ensure SecretsTask is deprecated/reference-only