### PR TITLE
[codex] Clarify Monad mainnet ABI and randomness docs

### DIFF
--- a/docs-by-chain/evm/monad.md
+++ b/docs-by-chain/evm/monad.md
@@ -9,12 +9,37 @@ If `NETWORK` is unset, the examples default to `monad-testnet`.
 
 ## Network Information
 
-| Network | Chain ID | Default RPC | Switchboard Contract |
+| Network | Chain ID | Default RPC | Switchboard Proxy |
 | --- | --- | --- | --- |
 | Monad Testnet | `10143` | `https://testnet-rpc.monad.xyz` | `0x6724818814927e057a693f4e3A172b6cC1eA690C` |
 | Monad Mainnet | `143` | `https://rpc.monad.xyz` | `0xB7F03eee7B9F56347e32cC71DaD65B303D5a0E67` |
 
 `RPC_URL` remains available as an override, but it must still resolve to the chain implied by `NETWORK`.
+
+## Monad Mainnet Contract Details
+
+Monad mainnet uses an ERC1967 proxy. The address apps integrate with is the proxy at `0xB7F03eee7B9F56347e32cC71DaD65B303D5a0E67`, and the user-facing ABI is the Switchboard implementation ABI.
+
+| Item | Value |
+| --- | --- |
+| Proxy address | `0xB7F03eee7B9F56347e32cC71DaD65B303D5a0E67` |
+| Proxy code page | [MonadScan proxy code](https://monadscan.com/address/0xB7F03eee7B9F56347e32cC71DaD65B303D5a0E67#code) |
+| Current implementation | `0x140E3f2E66619FE1113D971291990caC0b5b72Fd` |
+| Implementation code page | [MonadScan implementation code](https://monadscan.com/address/0x140E3f2E66619FE1113D971291990caC0b5b72Fd#code) |
+| Canonical ABI | `@switchboard-xyz/on-demand-solidity/abis/Switchboard.json` |
+| ABI source | [Switchboard ABI in `on-demand-solidity`](https://github.com/switchboard-xyz/sbv3/blob/main/javascript/on-demand-solidity/abis/Switchboard.json) |
+
+> MonadScan code visibility for the live mainnet implementation is still being repaired from the exact deployment source. Until that is finished, use the package ABI above instead of guessing from an empty or stale explorer ABI.
+
+## Randomness API Note
+
+The current EVM randomness interface is:
+
+- `createRandomness`
+- `settleRandomness`
+- `getRandomness`
+
+`revealRandomness` and `getRandomnessResult` are not part of the current Switchboard EVM interface on Monad.
 
 ## Shared Env Contract
 

--- a/docs-by-chain/evm/randomness/README.md
+++ b/docs-by-chain/evm/randomness/README.md
@@ -33,6 +33,11 @@ This means that Switchboard oracles can generate safe and fair randomness that i
 
 ## How to Use Switchboard Randomness
 
+For the current EVM interface, the public randomness flow uses `createRandomness`, `settleRandomness`, and `getRandomness`.
+`revealRandomness` and `getRandomnessResult` are not current Switchboard methods.
+
+The canonical JS/TS ABI lives at `@switchboard-xyz/on-demand-solidity/abis/Switchboard.json`.
+
 To understand the flow, it's helpful to visualize the following 5 parties.
 
 - **Alice**: blockchain user

--- a/docs-by-chain/evm/randomness/randomness-tutorial.md
+++ b/docs-by-chain/evm/randomness/randomness-tutorial.md
@@ -15,6 +15,8 @@ Play Pancake Stacker directly in your browser! Connect your wallet (MetaMask or 
 This tutorial walks you through building **Pancake Stacker**, a simple on-chain game that demonstrates Switchboard's randomness system. You'll learn how to request, resolve, and use verifiable randomness in your EVM smart contracts.
 
 > **Version source of truth:** [SDK Version Matrix](../../../tooling/sdk-version-matrix.md)
+>
+> **API note:** The current EVM randomness methods are `createRandomness`, `settleRandomness`, and `getRandomness`. Use the canonical ABI at `@switchboard-xyz/on-demand-solidity/abis/Switchboard.json`. `revealRandomness` and `getRandomnessResult` are not part of the current interface.
 
 ## What You'll Build
 


### PR DESCRIPTION
## Summary
- document the live Monad mainnet proxy and current implementation addresses
- point readers at the canonical ABI in @switchboard-xyz/on-demand-solidity instead of relying on explorer ABI pages
- call out the current randomness surface explicitly: createRandomness, settleRandomness, and getRandomness

## Why
The customer confusion came from an empty or stale Monad explorer code page plus older method-name guesses showing up in the wild. The docs should make the current interface and the canonical ABI source obvious.

## Impact
- Monad readers get the current mainnet proxy address and implementation address in one place
- docs now explain that Monad mainnet uses an ERC1967 proxy and that the user-facing ABI is the implementation ABI
- randomness docs now steer users away from revealRandomness and getRandomnessResult

## Validation
- reviewed the updated Monad chain page and randomness pages against the current examples and ABI package
- confirmed the docs point at the canonical package ABI path and current MonadScan URLs

## Notes
The docs stay honest about the remaining mainnet explorer-verification blocker. Until the exact deployment source is recovered, users should use the published package ABI rather than guessing from the explorer page.