### PR TITLE
[codex] Publish SAIL page in AI agents docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -35,7 +35,6 @@
 * [Aptos](docs-by-chain/aptos/aptos.md)
 * [Iota](docs-by-chain/iota/iota.md)
 * [Movement](docs-by-chain/movement/movement.md)
-* [SAIL](docs-by-chain/sail.md)
 
 ## Custom Feeds
 
@@ -101,6 +100,7 @@
 ## AI Agents / LLMs
 
 * [Overview](ai-agents-llms/README.md)
+* [SAIL](ai-agents-llms/sail.md)
 * [Switchboard Agent Skill](ai-agents-llms/skills/switchboard-agent-skill.md)
   * [Switchboard Solana/SVM Feeds Skill](ai-agents-llms/skills/switchboard-solana-svm-feeds.md)
   * [Switchboard EVM Feeds Skill](ai-agents-llms/skills/switchboard-evm-feeds.md)

--- a/ai-agents-llms/sail.md
+++ b/ai-agents-llms/sail.md
@@ -1,7 +1,3 @@
----
-hidden: true
----
-
 # SAIL
 
 If you're building decentralised applications that use AI, you've come to the right place!


### PR DESCRIPTION
## Summary

- Move the existing SAIL page from `docs-by-chain/` into `ai-agents-llms/`, where it fits the AI-agent focused content.
- Remove the `hidden: true` frontmatter so GitBook can publish it normally.
- Rewrite the SAIL page as a concise public overview aligned with the current docs, SDK surface, and examples state.
- Link to TEE architecture, Surge docs, and the advanced `@switchboard-xyz/sail-sdk` surface while noting that `sb-on-demand-examples` does not currently include a runnable SAIL example.

## Validation

- `git diff --check HEAD~1..HEAD`
- `SUMMARY.md` and SAIL relative link existence check with Node
- Checked docs for SAIL example claims