### PR TITLE
[codex] Update SDK documentation pins

### DIFF
--- a/ai-agents-llms/skills/switchboard-agent-skill.md
+++ b/ai-agents-llms/skills/switchboard-agent-skill.md
@@ -19,14 +19,14 @@ Provide a compact “front door” for all Switchboard work:
 
 Use exact pins from the [SDK Version Matrix](../../tooling/sdk-version-matrix.md).
 
-- `@switchboard-xyz/on-demand@3.9.0`
-- `@switchboard-xyz/common@5.7.0`
+- `@switchboard-xyz/on-demand@3.10.3`
+- `@switchboard-xyz/common@5.8.2`
 - `@switchboard-xyz/on-demand-solidity@1.1.0`
-- `@switchboard-xyz/sui-sdk@0.1.14`
+- `@switchboard-xyz/sui-sdk@0.1.16`
 - `@switchboard-xyz/aptos-sdk@0.1.5`
 - `@switchboard-xyz/iota-sdk@0.0.3`
-- `switchboard-on-demand = "0.11.3"`
-- `switchboard-protos = "0.2.4"`
+- `switchboard-on-demand = "0.13.0"`
+- `switchboard-protos = "0.2.6"`
 
 ## Scope
 

--- a/ai-agents-llms/skills/switchboard-crossbar-ops.md
+++ b/ai-agents-llms/skills/switchboard-crossbar-ops.md
@@ -22,7 +22,7 @@ Operate and use Crossbar for:
 
 Use exact pins from the [SDK Version Matrix](../../tooling/sdk-version-matrix.md).
 
-- `@switchboard-xyz/common@5.7.0`
+- `@switchboard-xyz/common@5.8.2`
 - `@switchboard-xyz/cli@3.5.12` (optional for CLI workflows)
 
 ## Defaults

--- a/ai-agents-llms/skills/switchboard-evm-feeds.md
+++ b/ai-agents-llms/skills/switchboard-evm-feeds.md
@@ -21,9 +21,9 @@ Integrate Switchboard on-demand feeds into EVM contracts and bots:
 
 Use exact pins from the [SDK Version Matrix](../../tooling/sdk-version-matrix.md).
 
-- `@switchboard-xyz/common@5.7.0`
+- `@switchboard-xyz/common@5.8.2`
 - `@switchboard-xyz/on-demand-solidity@1.1.0`
-- `ethers@6.16.0`
+- `ethers@6.13.1`
 
 ## Preconditions
 

--- a/ai-agents-llms/skills/switchboard-feed-design.md
+++ b/ai-agents-llms/skills/switchboard-feed-design.md
@@ -21,7 +21,7 @@ Turn a data requirement into a robust, verifiable feed definition:
 
 Use exact pins from the [SDK Version Matrix](../../tooling/sdk-version-matrix.md).
 
-- `@switchboard-xyz/common@5.7.0`
+- `@switchboard-xyz/common@5.8.2`
 
 This skill designs feed definitions. Integration details (atomic update+use, on-chain verifier patterns) belong to chain-specific skills.
 

--- a/ai-agents-llms/skills/switchboard-iota-feeds.md
+++ b/ai-agents-llms/skills/switchboard-iota-feeds.md
@@ -21,7 +21,7 @@ Use Switchboard on-demand feeds on Iota:
 Use exact pins from the [SDK Version Matrix](../../tooling/sdk-version-matrix.md).
 
 - `@switchboard-xyz/iota-sdk@0.0.3`
-- `@switchboard-xyz/common@5.7.0`
+- `@switchboard-xyz/common@5.8.2`
 - `@iota/iota-sdk@1.11.0`
 
 ## Preconditions

--- a/ai-agents-llms/skills/switchboard-randomness.md
+++ b/ai-agents-llms/skills/switchboard-randomness.md
@@ -19,8 +19,8 @@ Implement verifiable randomness with Switchboard:
 
 Use exact pins from the [SDK Version Matrix](../../tooling/sdk-version-matrix.md).
 
-- `switchboard-on-demand = "0.11.3"` (Solana Rust)
-- `@switchboard-xyz/common@5.7.0` (EVM off-chain resolution)
+- `switchboard-on-demand = "0.13.0"` (Solana Rust)
+- `@switchboard-xyz/common@5.8.2` (EVM off-chain resolution)
 - `@switchboard-xyz/on-demand-solidity@1.1.0` (EVM on-chain interfaces)
 
 ## Preconditions

--- a/ai-agents-llms/skills/switchboard-solana-svm-feeds.md
+++ b/ai-agents-llms/skills/switchboard-solana-svm-feeds.md
@@ -20,11 +20,11 @@ Integrate Switchboard on-demand feeds into Solana/SVM transactions and programs:
 
 Use exact pins from the [SDK Version Matrix](../../tooling/sdk-version-matrix.md).
 
-- `@switchboard-xyz/on-demand@3.9.0`
-- `@switchboard-xyz/common@5.7.0`
-- `@solana/web3.js@1.98.4`
-- `@coral-xyz/anchor@0.32.1` (TypeScript client)
-- `switchboard-on-demand = "0.11.3"` (Rust on-chain)
+- `@switchboard-xyz/on-demand@3.10.3`
+- `@switchboard-xyz/common@5.8.2`
+- `@solana/web3.js@1.98.0`
+- `@coral-xyz/anchor@0.31.1` (TypeScript client)
+- `switchboard-on-demand = "0.13.0"` (Rust on-chain)
 
 This skill is about integration correctness, not designing new feed definitions (handled by `switchboard-feed-design`).
 

--- a/ai-agents-llms/skills/switchboard-sui-feeds.md
+++ b/ai-agents-llms/skills/switchboard-sui-feeds.md
@@ -21,8 +21,8 @@ Integrate Switchboard on-demand feeds into Sui Move contracts using the Quote Ve
 
 Use exact pins from the [SDK Version Matrix](../../tooling/sdk-version-matrix.md).
 
-- `@switchboard-xyz/sui-sdk@0.1.14`
-- `@switchboard-xyz/on-demand@3.9.0`
+- `@switchboard-xyz/sui-sdk@0.1.16`
+- `@switchboard-xyz/on-demand@3.10.3`
 - `@mysten/sui@1.38.0`
 
 ## Preconditions

--- a/ai-agents-llms/skills/switchboard-surge.md
+++ b/ai-agents-llms/skills/switchboard-surge.md
@@ -20,9 +20,9 @@ Use Switchboard Surge for low-latency streaming:
 
 Use exact pins from the [SDK Version Matrix](../../tooling/sdk-version-matrix.md).
 
-- `@switchboard-xyz/on-demand@3.9.0`
-- `@switchboard-xyz/common@5.7.0` (EVM conversion path)
-- `@switchboard-xyz/sui-sdk@0.1.14` (Sui conversion path)
+- `@switchboard-xyz/on-demand@3.10.3`
+- `@switchboard-xyz/common@5.8.2` (EVM conversion path)
+- `@switchboard-xyz/sui-sdk@0.1.16` (Sui conversion path)
 
 ## Preconditions
 

--- a/ai-agents-llms/skills/switchboard-x402.md
+++ b/ai-agents-llms/skills/switchboard-x402.md
@@ -21,9 +21,9 @@ Use X402 micropayments with Switchboard feeds to access any X402-protected resou
 
 Use exact pins from the [SDK Version Matrix](../../tooling/sdk-version-matrix.md).
 
-- `@switchboard-xyz/on-demand@3.9.0`
-- `@switchboard-xyz/common@5.7.0`
-- `@solana/web3.js@1.98.4`
+- `@switchboard-xyz/on-demand@3.10.3`
+- `@switchboard-xyz/common@5.8.2`
+- `@solana/web3.js@1.98.0`
 
 ## Preconditions
 

--- a/custom-feeds/build-and-deploy-feed/build-with-typescript.md
+++ b/custom-feeds/build-and-deploy-feed/build-with-typescript.md
@@ -56,7 +56,7 @@ A feed is a set of jobs. Oracles execute the jobs and then aggregate the results
 mkdir example
 cd example
 bun init
-bun add @switchboard-xyz/on-demand @switchboard-xyz/common
+bun add @switchboard-xyz/on-demand@3.10.3 @switchboard-xyz/common@5.8.2
 ```
 
 > Note: Some examples import `OracleJob` from `@switchboard-xyz/common`.  

--- a/custom-feeds/build-and-deploy-feed/deploy-feed.md
+++ b/custom-feeds/build-and-deploy-feed/deploy-feed.md
@@ -56,7 +56,7 @@ solana-keygen new --outfile path/to/solana-keypair.json
 ## Install
 
 ```bash
-bun add @switchboard-xyz/on-demand @switchboard-xyz/common
+bun add @switchboard-xyz/on-demand@3.10.3 @switchboard-xyz/common@5.8.2
 ```
 
 ## Deployment flow (TypeScript)

--- a/docs-by-chain/evm/price-feeds/price-feeds-tutorial.md
+++ b/docs-by-chain/evm/price-feeds/price-feeds-tutorial.md
@@ -553,7 +553,7 @@ cp -r sb-on-demand-examples/evm/price-feeds/src/switchboard your-project/src/
 Or install via npm:
 
 ```bash
-npm install @switchboard-xyz/on-demand-solidity
+npm install @switchboard-xyz/on-demand-solidity@1.1.0
 ```
 
 ### 2. Import and Use

--- a/docs-by-chain/evm/randomness/randomness-tutorial.md
+++ b/docs-by-chain/evm/randomness/randomness-tutorial.md
@@ -54,13 +54,13 @@ The two-stage flow maps directly to our two main functions:
 1. **Solidity SDK:**
 
 ```bash
-npm install @switchboard-xyz/on-demand-solidity
+npm install @switchboard-xyz/on-demand-solidity@1.1.0
 ```
 
 2. **TypeScript SDK** (for off-chain randomness resolution):
 
 ```bash
-npm install @switchboard-xyz/common ethers
+npm install @switchboard-xyz/common@5.8.2 ethers
 ```
 
 3. **Forge remappings** - Add to `remappings.txt`:

--- a/docs-by-chain/evm/surge/README.md
+++ b/docs-by-chain/evm/surge/README.md
@@ -59,9 +59,9 @@ Connect your wallet and subscribe at [explorer.switchboardlabs.xyz/subscriptions
 ### 2. Install the SDK
 
 ```bash
-npm install @switchboard-xyz/on-demand@3.9.0 @switchboard-xyz/common@5.7.0
+npm install @switchboard-xyz/on-demand@3.10.3 @switchboard-xyz/common@5.8.2
 # or
-yarn add @switchboard-xyz/on-demand@3.9.0 @switchboard-xyz/common@5.7.0
+yarn add @switchboard-xyz/on-demand@3.10.3 @switchboard-xyz/common@5.8.2
 ```
 
 ### 3. Connect and Stream

--- a/docs-by-chain/iota/iota.md
+++ b/docs-by-chain/iota/iota.md
@@ -16,19 +16,19 @@ To use Switchboard On-Demand, add the following dependencies to your project:
 #### NPM
 
 ```bash
-npm install @switchboard-xyz/iota-sdk@0.0.3 @switchboard-xyz/common@5.7.0 @iota/iota-sdk@1.11.0 --save
+npm install @switchboard-xyz/iota-sdk@0.0.3 @switchboard-xyz/common@5.8.2 @iota/iota-sdk@1.11.0 --save
 ```
 
 #### Bun
 
 ```bash
-bun add @switchboard-xyz/iota-sdk@0.0.3 @switchboard-xyz/common@5.7.0 @iota/iota-sdk@1.11.0
+bun add @switchboard-xyz/iota-sdk@0.0.3 @switchboard-xyz/common@5.8.2 @iota/iota-sdk@1.11.0
 ```
 
 #### PNPM
 
 ```bash
-pnpm add @switchboard-xyz/iota-sdk@0.0.3 @switchboard-xyz/common@5.7.0 @iota/iota-sdk@1.11.0
+pnpm add @switchboard-xyz/iota-sdk@0.0.3 @switchboard-xyz/common@5.8.2 @iota/iota-sdk@1.11.0
 ```
 
 ### Creating an Aggregator and Sending Transactions

--- a/docs-by-chain/solana-svm/prediction-market/prediction-market-tutorial.md
+++ b/docs-by-chain/solana-svm/prediction-market/prediction-market-tutorial.md
@@ -91,14 +91,14 @@ const quote = await queue.fetchQuoteIx(crossbar, [feed], {
 ```toml
 [dependencies]
 anchor-lang = "0.31.1"
-switchboard-on-demand = { version = "=0.10.3", features = ["anchor", "devnet"] }
-switchboard-protos = { version = "^0.2.1", features = ["serde"] }
+switchboard-on-demand = { version = "0.13.0", features = ["anchor", "devnet"] }
+switchboard-protos = { version = "0.2.6", features = ["serde"] }
 prost = "0.13"
 solana-program = ">=2,<3"
 faster-hex = "0.10.0"
 ```
 
-> **Note:** The current example program pins `switchboard-on-demand` to `=0.10.3` for the `anchor-lang 0.31.1` toolchain.
+> **Note:** The current example program uses `switchboard-on-demand 0.13.0` with the `anchor` and `devnet` features for the `anchor-lang 0.31.1` toolchain.
 
 ### Program Structure
 

--- a/docs-by-chain/solana-svm/price-feeds/advanced-price-feed.md
+++ b/docs-by-chain/solana-svm/price-feeds/advanced-price-feed.md
@@ -65,14 +65,22 @@ This allows conditional initialization only when needed.
 
 ### Program Structure
 
+Use the current Pinocchio and Switchboard dependencies:
+
+```toml
+[dependencies]
+switchboard-on-demand = { version = "0.13.0", features = ["pinocchio", "devnet"] }
+pinocchio = { version = "0.11.2", features = ["cpi"] }
+solana-msg = "2.2.1"
+```
+
 ```rust
-use pinocchio::{entrypoint, msg, ProgramResult};
+use pinocchio::{entrypoint, AccountView, Address, ProgramResult};
+use pinocchio::error::ProgramError;
+use solana_msg::msg;
 use switchboard_on_demand::{
-    QuoteVerifier, check_pubkey_eq, OracleQuote, Instructions, get_slot
+    check_pubkey_eq, get_slot, Instructions, OracleQuote, QuoteVerifier
 };
-use pinocchio::account_info::AccountInfo;
-use pinocchio::program_error::ProgramError;
-use pinocchio::pubkey::Pubkey;
 
 mod utils;
 use utils::{init_quote_account_if_needed, init_state_account_if_needed};
@@ -80,8 +88,8 @@ use utils::{init_quote_account_if_needed, init_state_account_if_needed};
 entrypoint!(process_instruction);
 
 pub fn process_instruction(
-    program_id: &Pubkey,
-    accounts: &[AccountInfo],
+    program_id: &Address,
+    accounts: &mut [AccountView],
     instruction_data: &[u8],
 ) -> ProgramResult {
     match instruction_data[0] {
@@ -102,8 +110,8 @@ The instruction discriminator is a single byte—no Anchor discriminator overhea
 The crank instruction writes oracle data for authorized signers:
 
 ```rust
-pub fn crank(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
-    let [quote, queue, state, payer, instructions_sysvar, _clock_sysvar]: &[AccountInfo; 6] =
+pub fn crank(program_id: &Address, accounts: &mut [AccountView]) -> ProgramResult {
+    let [quote, queue, state, payer, instructions_sysvar, _clock_sysvar]: &mut [AccountView; 6] =
         accounts.try_into().map_err(|_| ProgramError::NotEnoughAccountKeys)?;
 
     // Validate state account belongs to this program
@@ -113,21 +121,21 @@ pub fn crank(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
     }
 
     // Check payer matches authorized signer stored in state
-    let state_data = unsafe { state.borrow_data_unchecked() };
-    if !check_pubkey_eq(&state_data, payer.key()) {
+    let state_data = state.try_borrow()?;
+    if !check_pubkey_eq(&state_data[..32], payer.address()) {
         return Err(ProgramError::Custom(1)); // UnauthorizedSigner
     }
 
     // DANGER: Only use this if you trust the signer!
     // Bypasses cryptographic verification for speed
-    OracleQuote::write_from_ix_unchecked(instructions_sysvar, quote, queue.key(), 0);
+    OracleQuote::write_from_ix_unchecked(&*instructions_sysvar, quote, queue.address(), 0);
 
     Ok(())
 }
 ```
 
 **Key points:**
-- Uses `borrow_data_unchecked` for zero-copy state access
+- Uses `AccountView` accessors for low-overhead account reads and writes
 - `write_from_ix_unchecked` directly writes oracle data without Ed25519 verification
 - Only ~90 CU for the entire operation
 
@@ -136,20 +144,20 @@ pub fn crank(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
 The read instruction verifies and displays oracle data:
 
 ```rust
-pub fn read(_program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
-    let [quote, queue, clock_sysvar, slothashes_sysvar, instructions_sysvar]: &[AccountInfo; 5] =
+pub fn read(_program_id: &Address, accounts: &mut [AccountView]) -> ProgramResult {
+    let [quote, queue, clock_sysvar, slothashes_sysvar, instructions_sysvar]: &mut [AccountView; 5] =
         accounts.try_into().map_err(|_| ProgramError::NotEnoughAccountKeys)?;
 
-    let slot = get_slot(clock_sysvar);
+    let slot = get_slot(&*clock_sysvar);
 
     // Verify the oracle data with staleness check
     let quote_data = QuoteVerifier::new()
-        .slothash_sysvar(slothashes_sysvar)
-        .ix_sysvar(instructions_sysvar)
+        .slothash_sysvar(&*slothashes_sysvar)
+        .ix_sysvar(&*instructions_sysvar)
         .clock_slot(slot)
-        .queue(queue)
+        .queue(&*queue)
         .max_age(30)  // Reject data older than 30 slots (~12 seconds)
-        .verify_account(quote)
+        .verify_account(queue.address(), quote)
         .unwrap();
 
     msg!("Quote slot: {}", quote_data.slot());
@@ -174,15 +182,15 @@ pub fn read(_program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
 Initializes the authorization state account:
 
 ```rust
-pub fn init_state(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
-    let [state, payer, system_program]: &[AccountInfo; 3] =
+pub fn init_state(program_id: &Address, accounts: &mut [AccountView]) -> ProgramResult {
+    let [state, payer, system_program]: &mut [AccountView; 3] =
         accounts.try_into().map_err(|_| ProgramError::NotEnoughAccountKeys)?;
 
     // Create the state account PDA
     init_state_account_if_needed(program_id, state, payer, system_program)?;
 
     // Store the authorized signer (payer becomes the admin)
-    state.try_borrow_mut_data()?[..32].copy_from_slice(payer.key().as_ref());
+    state.try_borrow_mut()?[..32].copy_from_slice(payer.address().as_ref());
 
     Ok(())
 }
@@ -195,12 +203,12 @@ The state account stores a single 32-byte pubkey—the authorized cranker.
 Initializes the oracle quote account:
 
 ```rust
-pub fn init_oracle(program_id: &Pubkey, accounts: &[AccountInfo]) -> ProgramResult {
-    let [quote, queue, payer, system_program, instructions_sysvar]: &[AccountInfo; 5] =
+pub fn init_oracle(program_id: &Address, accounts: &mut [AccountView]) -> ProgramResult {
+    let [quote, queue, payer, system_program, instructions_sysvar]: &mut [AccountView; 5] =
         accounts.try_into().map_err(|_| ProgramError::NotEnoughAccountKeys)?;
 
     // Parse feed info from the Ed25519 instruction data
-    let quote_data = Instructions::parse_ix_data_unverified(instructions_sysvar, 0)
+    let quote_data = Instructions::parse_ix_data_unverified(&*instructions_sysvar, 0)
         .map_err(|_| ProgramError::InvalidInstructionData)?;
 
     // Create the quote account as a PDA derived from queue + feed IDs
@@ -227,11 +235,11 @@ The `utils.rs` module handles PDA derivation and account creation:
 pub const ORACLE_ACCOUNT_SIZE: usize = 8 + 32 + 1024; // discriminator + queue + data
 
 pub fn init_quote_account_if_needed(
-    program_id: &Pubkey,
-    oracle_account: &AccountInfo,
-    queue_account: &AccountInfo,
-    payer: &AccountInfo,
-    system_program: &AccountInfo,
+    program_id: &Address,
+    oracle_account: &mut AccountView,
+    queue_account: &mut AccountView,
+    payer: &mut AccountView,
+    system_program: &mut AccountView,
     oracle_quote: &OracleQuote,
 ) -> Result<(), ProgramError> {
     // Skip if already initialized
@@ -243,15 +251,14 @@ pub fn init_quote_account_if_needed(
     // Derive PDA from queue + feed IDs
     let feed_ids = oracle_quote.feed_ids();
     let mut seeds: Vec<&[u8]> = Vec::with_capacity(feed_ids.len() + 1);
-    seeds.push(queue_account.key().as_ref());
+    seeds.push(queue_account.address().as_ref());
     for feed_id in &feed_ids {
         seeds.push(feed_id.as_ref());
     }
 
-    let (canonical_address, bump) =
-        pinocchio::pubkey::find_program_address(&seeds, program_id);
+    let (canonical_address, bump) = Address::find_program_address(&seeds, program_id);
 
-    if canonical_address != *oracle_account.key() {
+    if canonical_address != *oracle_account.address() {
         return Err(ProgramError::InvalidArgument);
     }
 
@@ -266,20 +273,19 @@ pub fn init_quote_account_if_needed(
 pub const STATE_ACCOUNT_SIZE: usize = 32; // Single pubkey
 
 pub fn init_state_account_if_needed(
-    program_id: &Pubkey,
-    state_account: &AccountInfo,
-    payer: &AccountInfo,
-    system_program: &AccountInfo,
+    program_id: &Address,
+    state_account: &mut AccountView,
+    payer: &mut AccountView,
+    system_program: &mut AccountView,
 ) -> Result<(), ProgramError> {
     if state_account.lamports() != 0 {
         return Ok(());
     }
 
     // Derive PDA from "state" seed
-    let (expected_key, bump) =
-        pinocchio::pubkey::find_program_address(&[b"state"], program_id);
+    let (expected_key, bump) = Address::find_program_address(&[b"state"], program_id);
 
-    if state_account.key() != &expected_key {
+    if state_account.address() != &expected_key {
         return Err(ProgramError::InvalidArgument);
     }
 

--- a/docs-by-chain/solana-svm/price-feeds/basic-price-feed.md
+++ b/docs-by-chain/solana-svm/price-feeds/basic-price-feed.md
@@ -374,10 +374,10 @@ In your `Cargo.toml`:
 
 ```toml
 [dependencies]
-switchboard-on-demand = { version = "=0.10.3", features = ["anchor", "devnet"] }
+switchboard-on-demand = { version = "0.13.0", features = ["anchor", "devnet"] }
 ```
 
-The example program pins `=0.10.3` on devnet. If you are targeting a different Solana cluster, swap the cluster feature to match your deployment.
+The example program enables the `devnet` feature. If you are targeting a different Solana cluster, swap the cluster feature to match your deployment.
 
 ### 2. Add the Account Struct
 

--- a/docs-by-chain/solana-svm/randomness/randomness-tutorial.md
+++ b/docs-by-chain/solana-svm/randomness/randomness-tutorial.md
@@ -115,7 +115,7 @@ Why? If you take payment on reveal, a malicious user could:
 ```toml
 [dependencies]
 anchor-lang = "0.31.1"
-switchboard-on-demand = { version = "0.10.0", features = ["anchor"] }
+switchboard-on-demand = { version = "0.13.0", features = ["anchor"] }
 ```
 
 ### Program Structure

--- a/docs-by-chain/solana-svm/surge/README.md
+++ b/docs-by-chain/solana-svm/surge/README.md
@@ -59,9 +59,9 @@ Connect your wallet and subscribe at [explorer.switchboardlabs.xyz/subscriptions
 ### 2. Install the SDK
 
 ```bash
-npm install @switchboard-xyz/on-demand@3.9.0
+npm install @switchboard-xyz/on-demand@3.10.3
 # or
-yarn add @switchboard-xyz/on-demand@3.9.0
+yarn add @switchboard-xyz/on-demand@3.10.3
 ```
 
 ### 3. Connect and Stream

--- a/docs-by-chain/solana-svm/surge/surge-tutorial.md
+++ b/docs-by-chain/solana-svm/surge/surge-tutorial.md
@@ -15,9 +15,9 @@ This tutorial walks you through implementing Switchboard Surge for real-time pri
 ## Installation
 
 ```bash
-npm install @switchboard-xyz/on-demand@3.9.0
+npm install @switchboard-xyz/on-demand@3.10.3
 # or
-yarn add @switchboard-xyz/on-demand@3.9.0
+yarn add @switchboard-xyz/on-demand@3.10.3
 ```
 
 ## Basic Implementation

--- a/docs-by-chain/sui/price-feeds/price-feeds-tutorial.md
+++ b/docs-by-chain/sui/price-feeds/price-feeds-tutorial.md
@@ -661,7 +661,7 @@ public struct MyProtocol has key {
 ### 4. TypeScript Dependencies
 
 ```bash
-npm install @switchboard-xyz/sui-sdk@0.1.14 @mysten/sui@1.38.0
+npm install @switchboard-xyz/sui-sdk@0.1.16 @mysten/sui@1.38.0
 ```
 
 ## Available Feeds

--- a/docs-by-chain/sui/surge/README.md
+++ b/docs-by-chain/sui/surge/README.md
@@ -59,9 +59,9 @@ Connect your wallet and subscribe at [explorer.switchboardlabs.xyz/subscriptions
 ### 2. Install the SDK
 
 ```bash
-npm install @switchboard-xyz/on-demand@3.9.0 @switchboard-xyz/sui-sdk@0.1.14 @mysten/sui@1.38.0 @solana/web3.js@1.98.4
+npm install @switchboard-xyz/on-demand@3.10.3 @switchboard-xyz/sui-sdk@0.1.16 @mysten/sui@1.38.0 @solana/web3.js@1.98.4
 # or
-yarn add @switchboard-xyz/on-demand@3.9.0 @switchboard-xyz/sui-sdk@0.1.14 @mysten/sui@1.38.0 @solana/web3.js@1.98.4
+yarn add @switchboard-xyz/on-demand@3.10.3 @switchboard-xyz/sui-sdk@0.1.16 @mysten/sui@1.38.0 @solana/web3.js@1.98.4
 ```
 
 ### 3. Connect and Stream

--- a/docs-by-chain/sui/surge/surge-tutorial.md
+++ b/docs-by-chain/sui/surge/surge-tutorial.md
@@ -396,7 +396,7 @@ Update #2 | Price: 97235.10 | Latency: 92ms | Avg: 88.5ms
 ### Dependencies
 
 ```bash
-npm install @switchboard-xyz/on-demand@3.9.0 @switchboard-xyz/sui-sdk@0.1.14 @mysten/sui@1.38.0 @solana/web3.js@1.98.4
+npm install @switchboard-xyz/on-demand@3.10.3 @switchboard-xyz/sui-sdk@0.1.16 @mysten/sui@1.38.0 @solana/web3.js@1.98.4
 ```
 
 ### Minimal Integration

--- a/tooling/sdk-version-matrix.md
+++ b/tooling/sdk-version-matrix.md
@@ -22,7 +22,7 @@ This page is the version reference for Switchboard docs, examples, and verifier 
 
 ## Canonical Docs Pin Set
 
-These are the current docs pins for examples-verified flows.
+These are the current docs pins. Example-backed pins match the observed versions above; docs-only pins are listed as the versions already used by their pages.
 
 | Package / Crate | Canonical Pin | Notes |
 | --- | --- | --- |
@@ -41,7 +41,7 @@ These are the current docs pins for examples-verified flows.
 | --- | --- | --- |
 | `@solana/web3.js` | `1.98.0` | Matches current Solana examples. |
 | `@mysten/sui` | `1.38.0` | Compatible with current Sui docs/examples import surface. |
-| `@aptos-labs/ts-sdk` | `6.1.0` | Aptos + Movement smoke projects. |
+| `@aptos-labs/ts-sdk` | `6.1.0` | Used by the Aptos and Movement docs. |
 | `@iota/iota-sdk` | `1.11.0` | Iota smoke projects. |
 | `ethers` | `6.13.1` | Matches the current EVM price-feeds example manifest. |
 | `@coral-xyz/anchor` | `0.31.1` | Matches the current Solana example manifests. |

--- a/tooling/sdk-version-matrix.md
+++ b/tooling/sdk-version-matrix.md
@@ -2,37 +2,38 @@
 
 This page is the version reference for Switchboard docs, examples, and verifier tooling.
 
-- Baseline date: **March 24, 2026**
+- Baseline date: **June 12, 2026**
 - Source of truth: [`tooling/sdk-versions.lock.json`](sdk-versions.lock.json)
 - The lock file now tracks two different views:
-  - `sdk_versions` / `companion_versions`: the **canonical verifier pin set** used by local audit scripts
+  - `sdk_versions` / `companion_versions`: the **canonical docs pin set** used by current docs and compatibility checks
   - `observed_example_versions`: the **exact versions currently pinned in the checked-in `sb-on-demand-examples` manifests**
 
 ## Observed Versions In Current Examples
 
 | Package / Crate | Observed Version(s) | Current Example References | Notes |
 | --- | --- | --- | --- |
-| `@switchboard-xyz/on-demand` | `^3.9.0` | `common`, `solana/feeds/*`, `solana/prediction-market`, `solana/randomness/coin-flip`, `solana/surge`, `solana/x402`, `sui/feeds/basic`, `sui/surge/basic` | Current TypeScript examples are aligned. |
-| `@switchboard-xyz/common` | `^5.7.0` | `common`, `common/twitter-follower-count`, `evm/*`, `solana/feeds/*`, `solana/prediction-market`, `solana/randomness/coin-flip`, `solana/surge`, `solana/x402` | Current TypeScript examples are aligned. |
-| `@switchboard-xyz/on-demand-solidity` | `^0.0.4`, `^1.1.0` | `evm/price-feeds`, `evm/randomness/*` | Price-feeds and randomness are on different package generations. |
-| `@switchboard-xyz/sui-sdk` | `^0.1.14` | `sui/feeds/basic`, `sui/surge/basic` | Aligned across current Sui examples. |
-| `switchboard-on-demand` | `0.11.3`, `=0.10.3`, `0.10.0` | `common/rust-feed-creation`, `solana/feeds/*`, `solana/prediction-market`, `solana/randomness/coin-flip` | Rust examples are also split by flow. |
-| `switchboard-protos` | `^0.2.1` | `solana/prediction-market` | Only used by the prediction-market program. |
+| `@switchboard-xyz/on-demand` | `^3.10.3` | `common`, `solana/feeds/*`, `solana/prediction-market`, `solana/randomness/coin-flip`, `solana/surge`, `solana/x402`, `sui/feeds/basic`, `sui/surge/basic` | Current TypeScript examples are aligned. |
+| `@switchboard-xyz/common` | `^5.8.2` | `common`, `common/twitter-follower-count`, `common/variable-overrides`, `evm/*`, `solana/feeds/*`, `solana/prediction-market`, `solana/randomness/coin-flip`, `solana/surge`, `solana/x402` | Current TypeScript examples are aligned. |
+| `@switchboard-xyz/on-demand-solidity` | `^1.1.0` | `evm/price-feeds`, `evm/randomness/*` | Current EVM examples are aligned. |
+| `@switchboard-xyz/sui-sdk` | `^0.1.16` | `sui/feeds/basic`, `sui/surge/basic` | Aligned across current Sui examples. |
+| `switchboard-on-demand` | `0.13.0` | `common/rust-feed-creation`, `solana/feeds/*`, `solana/prediction-market`, `solana/randomness/coin-flip` | Current Rust examples are aligned. |
+| `switchboard-protos` | `0.2.6` | `solana/prediction-market` | Only used by the prediction-market program. |
+| `pinocchio` | `0.11.2` | `solana/feeds/advanced` | Companion dependency for the low-CU Pinocchio example. |
 
-## Canonical Verifier Pin Set
+## Canonical Docs Pin Set
 
-These are the pins currently used by `scripts/verify-switchboard-deps.sh` and related tooling when it normalizes manifests for compatibility checks.
+These are the current docs pins for examples-verified flows.
 
 | Package / Crate | Canonical Pin | Notes |
 | --- | --- | --- |
-| `@switchboard-xyz/on-demand` | `3.9.0` | Matches the current TypeScript example set. |
-| `@switchboard-xyz/common` | `5.7.0` | Matches the current shared EVM and Solana TypeScript examples. |
-| `@switchboard-xyz/on-demand-solidity` | `1.1.0` | Canonical Solidity interface pin for verifier runs. |
-| `@switchboard-xyz/sui-sdk` | `0.1.14` | Matches current Sui examples. |
-| `@switchboard-xyz/aptos-sdk` | `0.1.5` | Used in smoke projects. |
-| `@switchboard-xyz/iota-sdk` | `0.0.3` | Used in smoke projects. |
-| `switchboard-on-demand` | `0.11.3` | Verifier pin; actual Solana program manifests currently vary by example. |
-| `switchboard-protos` | `0.2.4` | Verifier pin for Rust compatibility checks. |
+| `@switchboard-xyz/on-demand` | `3.10.3` | Matches the current TypeScript example set. |
+| `@switchboard-xyz/common` | `5.8.2` | Matches the current shared EVM and Solana TypeScript examples. |
+| `@switchboard-xyz/on-demand-solidity` | `1.1.0` | Current Solidity interface pin. |
+| `@switchboard-xyz/sui-sdk` | `0.1.16` | Matches current Sui examples. |
+| `@switchboard-xyz/aptos-sdk` | `0.1.5` | Used by the Aptos and Movement docs. |
+| `@switchboard-xyz/iota-sdk` | `0.0.3` | Current docs pin. |
+| `switchboard-on-demand` | `0.13.0` | Matches current Rust examples. |
+| `switchboard-protos` | `0.2.6` | Matches the current prediction-market example. |
 
 ## Companion Dependencies
 
@@ -44,6 +45,7 @@ These are the pins currently used by `scripts/verify-switchboard-deps.sh` and re
 | `@iota/iota-sdk` | `1.11.0` | Iota smoke projects. |
 | `ethers` | `6.13.1` | Matches the current EVM price-feeds example manifest. |
 | `@coral-xyz/anchor` | `0.31.1` | Matches the current Solana example manifests. |
+| `pinocchio` | `0.11.2` | Matches the advanced Solana price-feed example. |
 
 ## Toolchain Baseline
 
@@ -56,12 +58,11 @@ These are the pins currently used by `scripts/verify-switchboard-deps.sh` and re
 | Solana CLI | `2.3.11` |
 | Foundry (`forge`) | `1.5.0` |
 | Aptos CLI | `8.1.0` |
-| Sui CLI | `1.66.2` |
+| Sui CLI | `1.73.1` |
 
 ## Known Notes
 
-- Current TypeScript example manifests are aligned on `@switchboard-xyz/on-demand@^3.9.0` and `@switchboard-xyz/common@^5.7.0`.
+- Current TypeScript example manifests are aligned on `@switchboard-xyz/on-demand@^3.10.3` and `@switchboard-xyz/common@^5.8.2`.
 - `@mysten/sui` latest `2.x` still breaks the import surface used in current docs/examples, so `1.38.0` remains pinned.
-- `@switchboard-xyz/on-demand-solidity` is still split by flow: `evm/price-feeds` uses `^0.0.4` while the randomness examples use `^1.1.0`.
-- `solana/prediction-market` may hit `edition2024` dependency parsing under current Solana toolchains. If `cargo build-sbf` fails there, fall back to a host-side cargo check.
+- Current Solana Rust examples use `switchboard-on-demand = "0.13.0"`. The advanced Pinocchio price-feed example uses `pinocchio = "0.11.2"` and the `AccountView` API.
 - `sui/feeds/basic` defaults its checked-in `Move.toml` to testnet. Use the explicit `build:testnet`, `build:mainnet`, `deploy:testnet`, and `deploy:mainnet` scripts when documenting or verifying flows.

--- a/tooling/sdk-versions.lock.json
+++ b/tooling/sdk-versions.lock.json
@@ -9,7 +9,8 @@
   "drift_exceptions": {
     "npm": {
       "@mysten/sui": "Latest 2.x breaks current import surface used in docs/examples; upgrade after migration.",
-      "@switchboard-xyz/aptos-sdk": "Current Aptos and Movement docs pin."
+      "@switchboard-xyz/aptos-sdk": "Current Aptos and Movement docs pin.",
+      "@aptos-labs/ts-sdk": "Current Aptos and Movement docs pin."
     }
   },
   "sdk_versions": {

--- a/tooling/sdk-versions.lock.json
+++ b/tooling/sdk-versions.lock.json
@@ -1,28 +1,29 @@
 {
   "schema_version": 1,
-  "baseline_date": "2026-03-24",
+  "baseline_date": "2026-06-12",
   "policy": {
     "pinning": "exact",
     "scope": "current flows only (legacy excluded)",
-    "status_model": "single canonical verifier set + observed example pins"
+    "status_model": "canonical docs pin set + observed current-example pins"
   },
   "drift_exceptions": {
     "npm": {
-      "@mysten/sui": "Latest 2.x breaks current import surface used in docs/examples; upgrade after migration."
+      "@mysten/sui": "Latest 2.x breaks current import surface used in docs/examples; upgrade after migration.",
+      "@switchboard-xyz/aptos-sdk": "Current Aptos and Movement docs pin."
     }
   },
   "sdk_versions": {
     "npm": {
-      "@switchboard-xyz/on-demand": "3.9.0",
-      "@switchboard-xyz/common": "5.7.0",
+      "@switchboard-xyz/on-demand": "3.10.3",
+      "@switchboard-xyz/common": "5.8.2",
       "@switchboard-xyz/on-demand-solidity": "1.1.0",
-      "@switchboard-xyz/sui-sdk": "0.1.14",
+      "@switchboard-xyz/sui-sdk": "0.1.16",
       "@switchboard-xyz/aptos-sdk": "0.1.5",
       "@switchboard-xyz/iota-sdk": "0.0.3"
     },
     "crates": {
-      "switchboard-on-demand": "0.11.3",
-      "switchboard-protos": "0.2.4"
+      "switchboard-on-demand": "0.13.0",
+      "switchboard-protos": "0.2.6"
     }
   },
   "companion_versions": {
@@ -33,13 +34,16 @@
       "@iota/iota-sdk": "1.11.0",
       "ethers": "6.13.1",
       "@coral-xyz/anchor": "0.31.1"
+    },
+    "crates": {
+      "pinocchio": "0.11.2"
     }
   },
   "observed_example_versions": {
     "npm": {
       "@switchboard-xyz/on-demand": [
         {
-          "version": "^3.9.0",
+          "version": "^3.10.3",
           "references": [
             "common",
             "solana/feeds/basic",
@@ -55,10 +59,11 @@
       ],
       "@switchboard-xyz/common": [
         {
-          "version": "^5.7.0",
+          "version": "^5.8.2",
           "references": [
             "common",
             "common/twitter-follower-count",
+            "common/variable-overrides",
             "evm/price-feeds",
             "evm/randomness",
             "evm/randomness/coin-flip",
@@ -74,14 +79,9 @@
       ],
       "@switchboard-xyz/on-demand-solidity": [
         {
-          "version": "^0.0.4",
-          "references": [
-            "evm/price-feeds"
-          ]
-        },
-        {
           "version": "^1.1.0",
           "references": [
+            "evm/price-feeds",
             "evm/randomness/coin-flip",
             "evm/randomness/pancake-stacker"
           ]
@@ -89,10 +89,18 @@
       ],
       "@switchboard-xyz/sui-sdk": [
         {
-          "version": "^0.1.14",
+          "version": "^0.1.16",
           "references": [
             "sui/feeds/basic",
             "sui/surge/basic"
+          ]
+        }
+      ],
+      "@switchboard-xyz/iota-sdk": [
+        {
+          "version": "^0.0.3",
+          "references": [
+            "docs only; examples PR #60 did not include an Iota current example"
           ]
         }
       ],
@@ -167,31 +175,29 @@
     "crates": {
       "switchboard-on-demand": [
         {
-          "version": "0.11.3",
+          "version": "0.13.0",
           "references": [
-            "common/rust-feed-creation"
-          ]
-        },
-        {
-          "version": "=0.10.3",
-          "references": [
+            "common/rust-feed-creation",
             "solana/feeds/basic",
             "solana/feeds/advanced",
-            "solana/prediction-market"
-          ]
-        },
-        {
-          "version": "0.10.0",
-          "references": [
+            "solana/prediction-market",
             "solana/randomness/coin-flip"
           ]
         }
       ],
       "switchboard-protos": [
         {
-          "version": "^0.2.1",
+          "version": "0.2.6",
           "references": [
             "solana/prediction-market"
+          ]
+        }
+      ],
+      "pinocchio": [
+        {
+          "version": "0.11.2",
+          "references": [
+            "solana/feeds/advanced"
           ]
         }
       ]
@@ -205,11 +211,11 @@
     "solana_cli": "2.3.11",
     "foundry": "1.5.0",
     "aptos_cli": "8.1.0",
-    "sui_cli": "1.66.2"
+    "sui_cli": "1.73.1"
   },
   "verification": {
     "source_repo": "../sb-on-demand-examples",
-    "last_verified": "2026-03-24",
+    "last_verified": "2026-06-12",
     "commands": [
       {
         "id": "rust-common",
@@ -267,27 +273,16 @@
         "command": "pnpm install --frozen-lockfile || pnpm install && pnpm exec tsc --noEmit"
       },
       {
-        "id": "aptos-smoke",
-        "cwd": "/tmp/sb-sdk-smoke/aptos",
-        "command": "npm install && npx tsc --noEmit"
-      },
-      {
-        "id": "movement-smoke",
-        "cwd": "/tmp/sb-sdk-smoke/movement",
-        "command": "npm install && npx tsc --noEmit"
-      },
-      {
         "id": "iota-smoke",
         "cwd": "/tmp/sb-sdk-smoke/iota",
         "command": "npm install && npx tsc --noEmit"
       }
     ],
     "notes": [
-      "Current TypeScript example manifests are aligned on @switchboard-xyz/on-demand@^3.9.0 and @switchboard-xyz/common@^5.7.0; see observed_example_versions for the full per-package breakdown.",
+      "Current TypeScript example manifests are aligned on @switchboard-xyz/on-demand@^3.10.3 and @switchboard-xyz/common@^5.8.2; see observed_example_versions for the full per-package breakdown.",
       "@mysten/sui latest (2.x) is not yet compatible with current docs/examples imports; pinned to 1.38.0.",
-      "@switchboard-xyz/on-demand-solidity remains split across EVM flows: evm/price-feeds uses ^0.0.4 while the randomness examples use ^1.1.0.",
-      "solana/prediction-market build-sbf can fail on edition2024 transitive crates under current Solana toolchain cargo; verify with fallback host cargo check if encountered.",
-      "sui/feeds/basic contains an upstream failing Move unit test; treat build/typecheck as the dependency compatibility gate."
+      "Solana on-chain examples are aligned on switchboard-on-demand 0.13.0; the advanced Pinocchio example uses pinocchio 0.11.2 and AccountView.",
+      "sui/feeds/basic defaults its checked-in Move.toml to testnet. Use explicit build:testnet, build:mainnet, deploy:testnet, and deploy:mainnet scripts when documenting or verifying flows."
     ]
   }
 }


### PR DESCRIPTION
## Summary

- Update GitBook SDK version guidance from the verified current examples update.
- Refresh central SDK sources of truth in `tooling/sdk-version-matrix.md` and `tooling/sdk-versions.lock.json` with the June 12, 2026 baseline.
- Update stale user-facing install snippets for Solana/SVM, EVM, Sui, Iota, and custom feed docs.
- Update Solana Rust docs for `switchboard-on-demand 0.13.0`, `switchboard-protos 0.2.6`, and the current Pinocchio `0.11.2` / `AccountView` flow.
- Refresh AI-agent skill dependency sections for the SDKs covered by the current examples update.
- Keep Aptos and Movement chain docs and dedicated skill pages on their existing user-facing pins after checking both the current and proposed newer pin sets.

## Validation

- `git diff --check`
- `jq . tooling/sdk-versions.lock.json`
- stale SDK/reference scans for old Switchboard pins
- Aptos/Movement no-diff check for their chain docs and dedicated skill pages
- unversioned Switchboard install snippet scan
- `SUMMARY.md` no-drift check
- Aptos/Movement dependency check:
  - Current docs pins install and runtime `loadData` / `fetchUpdate` succeeds.
  - Proposed `@switchboard-xyz/aptos-sdk@0.2.2`, `@switchboard-xyz/common@5.8.2`, `@aptos-labs/ts-sdk@6.1.0` install and runtime `loadData` / `fetchUpdate` succeeds.
  - Both docs-style pin sets fail TypeScript compile because `@switchboard-xyz/aptos-sdk` still brings nested `@aptos-labs/ts-sdk@2.0.1` and `@switchboard-xyz/common@3.5.0`, which conflict with the top-level docs pins.
  - SDK-aligned pins using `@aptos-labs/ts-sdk@2.0.1` and `@switchboard-xyz/common@3.5.0` typecheck, but those are not the desired current docs pins.
  - Movement transaction simulation reached VM execution and failed only with `INSUFFICIENT_BALANCE_FOR_TRANSACTION_FEE` when using a generated unfunded account.

## Notes

- Aptos and Movement chain docs and dedicated skill pages were left unchanged.
- This PR intentionally does not modify `SUMMARY.md`.