### PR TITLE
doc: fix misled code example

### DIFF
--- a/docs-by-chain/solana-svm/price-feeds/basic-price-feed.md
+++ b/docs-by-chain/solana-svm/price-feeds/basic-price-feed.md
@@ -109,9 +109,7 @@ pub struct ReadOracleData<'info> {
 /// System variables required for oracle verification
 #[derive(Accounts)]
 pub struct Sysvars<'info> {
-    pub clock: Sysvar<'info, Clock>,
-    pub slothashes: Sysvar<'info, SlotHashes>,
-    pub instructions: Sysvar<'info, Instructions>,
+    pub clock: Sysvar<'info, Clock>
 }
 ```
 


### PR DESCRIPTION
I tried with code example of `Basic Price Feed Tutorial` and stuck at error `AnchorError caused by account: slothashes. Error Code: AccountSysvarMismatch. Error Number: 3015. Error Message: The given public key does not match the required sysvar.`.

It took me lots of time and tokens to figure out that the problem is that `slothashes` sysvars is not supported so well. And the `slothashes` is not even used in the code example.

I can run the code example successfully after remove both `slothashes` and `instructions`. 

I believe it should be a mistake to add them into the `Sysvars` and we'd better to remove them to protect beginners like me.  