### PR TITLE
[codex] Document feed parameter units

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -43,6 +43,7 @@
   * [Build with TypeScript](custom-feeds/build-and-deploy-feed/build-with-typescript.md)
   * [Deploy Feed](custom-feeds/build-and-deploy-feed/deploy-feed.md)
 * [Advanced Feed Configuration](custom-feeds/advanced-feed-configuration/README.md)
+  * [Feed Parameter Units](custom-feeds/advanced-feed-configuration/feed-parameter-units.md)
   * [Data Feed Variable Overrides](custom-feeds/advanced-feed-configuration/data-feed-variable-overrides.md)
   * [Variables with CacheTask](custom-feeds/advanced-feed-configuration/variables-with-cachetask.md)
   * [REST APIs with HttpTask](custom-feeds/advanced-feed-configuration/rest-apis-with-httptask.md)

--- a/ai-agents-llms/skills/switchboard-agent-skill.md
+++ b/ai-agents-llms/skills/switchboard-agent-skill.md
@@ -140,7 +140,8 @@ Notes:
 - These are starter defaults, not a bypass of required policy capture.
 - For non-Solana chains, keep the same safety posture and translate native token/key custody fields to chain-appropriate values.
 - Solana slot values are approximate mappings for documentation convenience (~400ms/slot).
-- `maxVariance` is chain-native and kept at `1e9` baseline unless explicitly overridden.
+- `maxVariance` is chain-native and kept at `1e9` baseline unless explicitly overridden; for these chain parameters, `1e9` means `1%`.
+- Raw v2 `OracleFeed.maxJobRangePct` uses the same `1e9` percent scale, but `MedianTask.max_range_percent` is a human percent string. See `custom-feeds/advanced-feed-configuration/feed-parameter-units.md` for the surface-specific units.
 
 ### Secret handling (mandatory)
 

--- a/ai-agents-llms/skills/switchboard-crossbar-ops.md
+++ b/ai-agents-llms/skills/switchboard-crossbar-ops.md
@@ -199,7 +199,7 @@ curl -s "$CROSSBAR/updates/evm/1116/$AGGREGATOR_ID" | jq .
 - IPFS store fails → verify IPFS credentials and outbound access
 - simulation intermittent errors → endpoints unstable; add source diversity/fallbacks
 - update fetch fails → network mismatch, RPC unreachable, queue mismatch
-- `ORACLE_UNAVAILABLE` on `/v2/update` after successful `/v2/fetch` and `/v2/simulate` → treat as managed oracle/gateway availability, not a missing permission
+- `ORACLE_UNAVAILABLE` on `/v2/update` after successful `/v2/fetch` and `/v2/simulate` -> check managed oracle/gateway availability and oracle-side validation errors such as `RangeExceeded`; raw v2 `maxJobRangePct` must be scaled by `1e9`
 - EVM custom feed not resolving → confirm you are using `/v2/fetch`, `/v2/simulate`, and `/v2/update`, not the legacy aggregator route
 - rate limits → self-host + caching + reduce polling
 

--- a/ai-agents-llms/skills/switchboard-evm-feeds.md
+++ b/ai-agents-llms/skills/switchboard-evm-feeds.md
@@ -175,7 +175,7 @@ Produce an `EvmFeedIntegrationPlan` including:
 - Stale timestamp → fetch fresh updates; raise max age only for non-critical paths
 - Wrong feed/network → verify feedId and deployment match chainId/network
 - Feed Builder custom feed on EVM → use `simulateFeed(...)` and `fetchV2Update(...)`, not `fetchEVMResults(...)`
-- `ORACLE_UNAVAILABLE` after successful simulation → treat as managed oracle/gateway availability, not a missing permission
+- `ORACLE_UNAVAILABLE` after successful simulation -> check managed oracle/gateway availability and oracle-side validation errors such as `RangeExceeded`; raw v2 `maxJobRangePct` must be scaled by `1e9`
 
 ## References
 

--- a/ai-agents-llms/skills/switchboard-feed-design.md
+++ b/ai-agents-llms/skills/switchboard-feed-design.md
@@ -151,7 +151,7 @@ Template 2: 3-source median (production minimum, 2 of 3 required)
 }
 ~~~
 
-Template 3: 5-source with fallback tolerance (production recommended)
+Template 3: 5-source with fallback tolerance (production recommended). In `MedianTask`, `max_range_percent` is a human percent string.
 
 ~~~json
 {
@@ -256,7 +256,7 @@ Variable override rule reminder:
 ### 4) Error handling and rate limiting
 
 - set `min_successful_required` so one source outage does not break updates (for example 2-of-3, 3-of-5)
-- set `max_range_percent` for drift/outlier protection before median is accepted
+- set `max_range_percent` for drift/outlier protection before median is accepted; this `MedianTask` field is a human percent string, not the raw v2 feed-level `maxJobRangePct` scale
 - stagger polling and cap request rate to provider quotas (especially free tiers)
 - back off exponentially on HTTP 429/5xx and keep at least 3 independent sources
 

--- a/custom-feeds/advanced-feed-configuration/README.md
+++ b/custom-feeds/advanced-feed-configuration/README.md
@@ -8,6 +8,8 @@ Switchboard Feeds enable seamless access to data from any API, oracle, major DeF
 
 Switchboard data feeds are composed of [Oracle Jobs](../build-and-deploy-feed/build-with-typescript.md#oracle-jobs-are-pipelines), which define where to source data. Feeds specify a list of different [Task Types](../task-types.md), which are used as instructions to fetch data.
 
+If you are configuring feed validation, start with [Feed Parameter Units](feed-parameter-units.md). Raw v2 `maxJobRangePct` is scaled by `1e9`, while task-level percent fields and SDK helper fields may use human percentages.
+
 This section will explore different task types and give an in-depth explanation on how to build oracle jobs.
 
 ## Task Runner

--- a/custom-feeds/advanced-feed-configuration/feed-parameter-units.md
+++ b/custom-feeds/advanced-feed-configuration/feed-parameter-units.md
@@ -1,0 +1,42 @@
+---
+title: Feed Parameter Units
+description: Units and fixed-point scaling for Switchboard feed configuration parameters.
+---
+
+# Feed Parameter Units
+
+Feed definitions combine validation parameters, quorum parameters, freshness limits, and returned feed values. These fields do not all use the same unit or fixed-point scale.
+
+The most common mistake is treating raw v2 `OracleFeed.maxJobRangePct` / `max_job_range_pct` as a human percent. It is a fixed-point percent scaled by `1e9`:
+
+- `1_000_000_000` means `1%`
+- `5_000_000_000` means `5%`
+- `5` does not mean `5%`; it is effectively zero tolerance
+
+| Field or surface | Unit | Example | Notes |
+| --- | --- | --- | --- |
+| Raw v2 `OracleFeed.maxJobRangePct` / `max_job_range_pct` | Percent scaled by `1e9` | `1_000_000_000` = `1%`; `5_000_000_000` = `5%` | Used in raw protobuf/JSON feed definitions. This is the feed-level job-spread tolerance oracles enforce before signing an update. |
+| SDK helper `maxVariance` inputs that scale internally | Human percent | `1` or `1.0` = `1%` | Some SDK helper methods accept the human percentage and multiply by `1e9` before sending a gateway or on-chain request. Check the method docs before passing raw integers. |
+| Direct gateway/raw API `max_variance` fields | Percent scaled by `1e9` | `50_000_000` = `0.05%`; `1_000_000_000` = `1%` | Use this for raw gateway payloads and chain parameters that already expect fixed-point validation values. Some JSON routes expose this as camelCase `maxVariance` while still expecting the scaled integer. |
+| `MedianTask.max_range_percent` | Human percent string | `"2.5"` = `2.5%` | This is a task-level setting inside `MedianTask`. It is not scaled like feed-level `maxJobRangePct`. |
+| `minJobResponses` / `min_job_responses` | Unscaled job/source quorum | `2` requires at least two successful job results | This counts successful jobs inside one oracle's feed execution. It does not change percent scaling. |
+| `minOracleSamples` / `min_oracle_samples` | Unscaled oracle/signature quorum | `3` requires three oracle samples | This counts oracle responses/signatures. It is separate from job/source quorum. |
+| Feed result values | Feed-specific numeric convention, often `i128` scaled by `1e18` | `1_000_000_000_000_000_000` may represent `1.0` | Result-value scaling is independent from validation parameter scaling. Always document the feed's value decimals separately. |
+| Staleness fields | Slots, seconds, or milliseconds depending on the surface | `maxStaleness: 150` slots; `maxAgeSeconds: 60`; `maxAgeMs: 60000` | Solana/SVM verifier settings often use slots. EVM and Move-chain examples commonly use seconds. Sui examples may use milliseconds. |
+
+## Practical Rules
+
+When you create a raw v2 `OracleFeed`, use scaled integers for feed-level range validation:
+
+```ts
+const feed = {
+  minJobResponses: 2,
+  minOracleSamples: 3,
+  maxJobRangePct: 1_000_000_000, // 1%, scaled by 1e9
+  jobs,
+};
+```
+
+Use `maxJobRangePct: 0` only when the flow intentionally expects a single successful job/source or identical outputs. For normal multi-source feeds, set a positive scaled tolerance.
+
+Simulation can succeed even when signed updates fail. Simulation proves the jobs can resolve off-chain; signed updates also require oracle-side feed validation to pass. If update fetching returns `ORACLE_UNAVAILABLE` after successful simulation, inspect oracle errors for validation failures such as `RangeExceeded`, then check whether `maxJobRangePct` was scaled correctly.

--- a/custom-feeds/build-and-deploy-feed/build-with-typescript.md
+++ b/custom-feeds/build-and-deploy-feed/build-with-typescript.md
@@ -191,6 +191,8 @@ Bounding can be applied:
 - within a job (reject a single bad API response)
 - at the feed level (reject updates when jobs disagree too much)
 
+> Feed-level validation fields use different units depending on the surface. Raw v2 `OracleFeed.maxJobRangePct` is scaled by `1e9` (`1_000_000_000` = `1%`), while `MedianTask.max_range_percent` is a human percent string. See [Feed Parameter Units](../advanced-feed-configuration/feed-parameter-units.md) before publishing a feed definition.
+
 ---
 
 ## Task reference

--- a/custom-feeds/build-and-deploy-feed/build-with-ui.md
+++ b/custom-feeds/build-and-deploy-feed/build-with-ui.md
@@ -129,6 +129,8 @@ The Feed Builder exposes common feed-level configuration knobs:
 
 These parameters are your “guardrails”—they trade off liveness vs correctness. Start conservative, then tune based on observed behavior.
 
+> Feed parameter units are surface-specific. Raw v2 `maxJobRangePct` is scaled by `1e9`, while some UI and SDK fields accept human percentages. See [Feed Parameter Units](../advanced-feed-configuration/feed-parameter-units.md) before copying values between surfaces.
+
 ### 5) Simulate and debug
 
 Use the UI’s simulation flow to validate:

--- a/custom-feeds/build-and-deploy-feed/deploy-feed.md
+++ b/custom-feeds/build-and-deploy-feed/deploy-feed.md
@@ -26,6 +26,8 @@ If you haven't designed and simulated your jobs yet, start here:
 - [Build with TypeScript](build-with-typescript.md) (code-first)
 - [Build with UI](build-with-ui.md) (UI-first)
 
+Before you publish a v2 feed definition, confirm the feed parameter units. Raw `OracleFeed.maxJobRangePct` is scaled by `1e9`, so `1_000_000_000` means `1%`. See [Feed Parameter Units](../advanced-feed-configuration/feed-parameter-units.md).
+
 ---
 
 # Solana / SVM: Deploy with Managed Updates

--- a/custom-feeds/task-types.md
+++ b/custom-feeds/task-types.md
@@ -836,6 +836,8 @@ _**Example**_: Returns the median numerical result of 3 jobs.
 | `min_successful_required` | int32 | The minimum number of values before a successful median can be yielded. |
 | `max_range_percent` | string | The maximum range between the minimum and maximum values before a successful median can be yielded. |
 
+`max_range_percent` is a human percent string for this `MedianTask` only. It is not scaled like feed-level raw v2 `OracleFeed.maxJobRangePct`; see [Feed Parameter Units](advanced-feed-configuration/feed-parameter-units.md).
+
 ---
 
 ### MinTask

--- a/docs-by-chain/aptos/aptos.md
+++ b/docs-by-chain/aptos/aptos.md
@@ -147,9 +147,9 @@ const minSampleSize = 1;
 const maxStalenessSeconds = 60;
 
 // If jobs diverge more than 1%, don't allow the feed to produce a valid update
-const maxVariance = 1e9;
+const maxVariance = 1e9; // 1%, scaled by 1e9 for this chain parameter
 
-// Require only 1 job response
+// Require only 1 job response (unscaled count)
 const minResponses = 1;
 
 //==========================================================

--- a/docs-by-chain/evm/monad.md
+++ b/docs-by-chain/evm/monad.md
@@ -203,7 +203,7 @@ await tx.wait();
   - `GET /v2/fetch/{feedId}`
   - `GET /v2/simulate/{feedId}?network=testnet|mainnet`
   - `GET /v2/update/{feedId}?chain=evm&network=testnet|mainnet&use_timestamp=true`
-- If `v2/fetch` and `v2/simulate` succeed but `v2/update` returns `ORACLE_UNAVAILABLE`, the issue is managed oracle or gateway availability for that feed, not a missing deployment step or permission.
+- If `v2/fetch` and `v2/simulate` succeed but `v2/update` returns `ORACLE_UNAVAILABLE`, the issue is not a missing deployment step or permission. It can be managed oracle/gateway availability, or oracle-side validation rejecting the feed result. Check oracle errors for `RangeExceeded`, especially if raw v2 `maxJobRangePct` was not scaled by `1e9`; see [Feed Parameter Units](../../custom-feeds/advanced-feed-configuration/feed-parameter-units.md).
 
 ## Notes
 

--- a/docs-by-chain/evm/price-feeds/price-feeds-tutorial.md
+++ b/docs-by-chain/evm/price-feeds/price-feeds-tutorial.md
@@ -655,7 +655,7 @@ Popular feeds include:
 | `PriceDeviationTooHigh` | Normal during high volatility; adjust `maxDeviationBps` if needed |
 | `PriceTooOld` | Fetch fresh data from Crossbar; adjust `maxPriceAge` if needed |
 | `InvalidFeedId` | Ensure the feed ID exists and has been updated at least once |
-| `ORACLE_UNAVAILABLE` | If `simulateFeed` works but `fetchV2Update` fails, treat it as oracle or gateway availability rather than a missing deployment step |
+| `ORACLE_UNAVAILABLE` | If `simulateFeed` works but `fetchV2Update` fails, it is not a missing deployment step. Check oracle/gateway availability and oracle-side validation errors such as `RangeExceeded`, especially if raw v2 `maxJobRangePct` was not scaled by `1e9`; see [Feed Parameter Units](../../../custom-feeds/advanced-feed-configuration/feed-parameter-units.md) |
 | Build errors | Bootstrap `forge-std` in `../randomness/coin-flip`, then rerun `forge build` |
 
 ## Next Steps

--- a/docs-by-chain/evm/surge/surge-tutorial.md
+++ b/docs-by-chain/evm/surge/surge-tutorial.md
@@ -109,7 +109,7 @@ async function convertSurgeToEvm() {
 
   // Perform the conversion
   const evmEncoded = EVMUtils.convertSurgeUpdateToEvmFormat(surgeData, {
-    minOracleSamples: 1
+    minOracleSamples: 1 // unscaled oracle-sample quorum
   });
 
   console.log('Encoded Data:', evmEncoded);
@@ -127,7 +127,7 @@ convertSurgeToEvm();
 import { EVMUtils } from '@switchboard-xyz/common';
 
 const evmEncoded = EVMUtils.convertSurgeUpdateToEvmFormat(surgeData, {
-  minOracleSamples: 1  // Minimum oracle samples required
+  minOracleSamples: 1  // Minimum oracle samples required; unscaled count
 });
 ```
 
@@ -261,7 +261,7 @@ async function submitSurgeUpdate(
 ) {
   // Convert Surge update to EVM format
   const evmEncoded = EVMUtils.convertSurgeUpdateToEvmFormat(surgeData, {
-    minOracleSamples: 1
+    minOracleSamples: 1 // unscaled oracle-sample quorum
   });
 
   // Get fee and submit
@@ -291,7 +291,7 @@ async function handleSurgeUpdate(surgeData: SurgeRawGatewayResponse) {
   try {
     // Convert to EVM format
     const evmEncoded = EVMUtils.convertSurgeUpdateToEvmFormat(surgeData, {
-      minOracleSamples: 1
+      minOracleSamples: 1 // unscaled oracle-sample quorum
     });
 
     // Submit to chain

--- a/docs-by-chain/iota/iota.md
+++ b/docs-by-chain/iota/iota.md
@@ -94,10 +94,10 @@ const minSampleSize = 1;
 const maxStalenessSeconds = 60;
 
 // If jobs diverge more than 1%, don't allow the feed to produce a valid update
-const maxVariance = 1e9;
+const maxVariance = 1e9; // 1%, scaled by 1e9 for this chain parameter
 
-// Require only 1 job response
-const minJobResponses = 1;
+// Require only 1 job response (unscaled count)
+const minJobResponses = 1; // unscaled job/source quorum
 
 //==========================================================
 // Feed Initialization On-Chain

--- a/docs-by-chain/movement/movement.md
+++ b/docs-by-chain/movement/movement.md
@@ -183,9 +183,9 @@ const minSampleSize = 1;
 const maxStalenessSeconds = 60;
 
 // If jobs diverge more than 1%, don't allow the feed to produce a valid update
-const maxVariance = 1e9;
+const maxVariance = 1e9; // 1%, scaled by 1e9 for this chain parameter
 
-// Require only 1 job response
+// Require only 1 job response (unscaled count)
 const minResponses = 1;
 
 //==========================================================

--- a/docs-by-chain/solana-svm/prediction-market/prediction-market-tutorial.md
+++ b/docs-by-chain/solana-svm/prediction-market/prediction-market-tutorial.md
@@ -196,9 +196,9 @@ fn create_kalshi_feed_id(order_id: &str) -> Result<[u8; 32]> {
                 weight: None,
             }
         ],
-        min_job_responses: Some(1),
-        min_oracle_samples: Some(1),
-        max_job_range_pct: Some(0),
+        min_job_responses: Some(1), // unscaled job/source quorum
+        min_oracle_samples: Some(1), // unscaled oracle/signature quorum
+        max_job_range_pct: Some(0), // Intentional for this single-source verification; use a positive scaled value for normal multi-source feeds.
     };
 
     // Encode as protobuf and hash
@@ -293,9 +293,9 @@ async function verifyKalshiFeed(
   // Step 3: Define the oracle feed
   const oracleFeed = {
     name: "Kalshi Order Price",
-    minJobResponses: 1,
-    minOracleSamples: 1,
-    maxJobRangePct: 0,
+    minJobResponses: 1, // unscaled job/source quorum
+    minOracleSamples: 1, // unscaled oracle/signature quorum
+    maxJobRangePct: 0, // Intentional for this single-source verification; use a positive scaled value for normal multi-source feeds.
     jobs: [
       {
         tasks: [

--- a/docs-by-chain/solana-svm/price-feeds/authority-updated-feeds.md
+++ b/docs-by-chain/solana-svm/price-feeds/authority-updated-feeds.md
@@ -226,7 +226,7 @@ const ix = OracleQuote.buildFeedAuthorityUpdateInstruction({
 });
 ```
 
-If you set `minOracleSamples` explicitly, use the same ordered feed list for both payload construction and PDA derivation.
+If you set `minOracleSamples` explicitly, treat it as an unscaled oracle-sample count and use the same ordered feed list for both payload construction and PDA derivation.
 
 ## Rust SDK Helpers
 

--- a/docs-by-chain/solana-svm/x402/x402-tutorial.md
+++ b/docs-by-chain/solana-svm/x402/x402-tutorial.md
@@ -121,9 +121,9 @@ This is the key difference from standard feeds. Instead of storing the feed on I
 ```typescript
 const ORACLE_FEED = {
   name: "X402 Paywalled RPC Call",
-  minJobResponses: 1,
-  minOracleSamples: 1,
-  maxJobRangePct: 0,
+  minJobResponses: 1, // unscaled job/source quorum
+  minOracleSamples: 1, // unscaled oracle/signature quorum
+  maxJobRangePct: 0, // Intentional for this single-use flow; use a positive scaled value for normal multi-source feeds.
   jobs: [
     {
       tasks: [

--- a/tooling/crossbar/README.md
+++ b/tooling/crossbar/README.md
@@ -18,6 +18,8 @@ Crossbar aims to streamline the Switchboard experience, offering the following c
 * **Store Jobs:** Store feed definitions using your configured IPFS node (requires Piñata credentials or a Kubo node).
 * **Simulate Feeds by Feed Hash:** Simulate multiple feeds simultaneously using their feed hashes, enabling off-chain tracking of custom price feeds for bot automation.
 
+> Crossbar exposes both simulation and signed-update paths. Simulation can succeed even when signed updates fail oracle-side validation. For validation units such as raw v2 `maxJobRangePct` and gateway `max_variance`, see [Feed Parameter Units](../../custom-feeds/advanced-feed-configuration/feed-parameter-units.md).
+
 ### Blockchain-Specific Features
 
 Crossbar provides tailored features for specific blockchains:

--- a/tooling/crossbar/api-endpoints.md
+++ b/tooling/crossbar/api-endpoints.md
@@ -29,6 +29,8 @@ For machine-readable schema and live testing:
 | `GET` | `/debug/cid/{hash}` | CID conversion/debug |
 | `GET` | `/debug/bnb` | Binance debug endpoint |
 
+Parameter units are surface-specific. Raw v2 `OracleFeed.maxJobRangePct` and raw gateway `max_variance` values are percentages scaled by `1e9`; `1_000_000_000` means `1%`. See [Feed Parameter Units](../../custom-feeds/advanced-feed-configuration/feed-parameter-units.md).
+
 ## EVM Route Selection
 
 Use different Crossbar routes depending on whether you are integrating a current Feed Builder/custom feed or an older aggregator-based EVM integration.
@@ -532,6 +534,8 @@ Response (`200`):
 #### `POST /gateways/fetch_signatures`
 
 Purpose: fetch signatures for a single feed/jobs request. Supports both legacy and new request shapes.
+
+`maxVariance` in these raw gateway request bodies is already scaled by `1e9`; `50_000_000` means `0.05%`.
 
 Legacy body (feed-hash based):
 


### PR DESCRIPTION
## Summary

- Add a canonical Feed Parameter Units page covering raw v2 `maxJobRangePct`, SDK helper `maxVariance`, raw gateway `max_variance`, `MedianTask.max_range_percent`, quorum fields, feed value scaling, and staleness units.
- Link or summarize the units guidance from feed-building, Crossbar, chain-specific, and AI-agent docs.
- Update `ORACLE_UNAVAILABLE` troubleshooting to call out oracle-side validation failures such as `RangeExceeded` when raw v2 `maxJobRangePct` is incorrectly scaled.

## Why

Raw v2 `OracleFeed.maxJobRangePct` / `max_job_range_pct` is a fixed-point percent scaled by `1e9`, so `1_000_000_000` means `1%`. Passing a human value like `5` effectively creates near-zero tolerance and can make signed updates fail even after simulation succeeds.

## Validation

- Ran the user-docs boundary scanner on touched Markdown files.
- Ran a search audit for `maxJobRangePct|max_job_range_pct|maxVariance|max_variance|max_range_percent|minJobResponses|minOracleSamples|ORACLE_UNAVAILABLE|RangeExceeded`.
- Ran `git diff --check`.