### PR TITLE
docs: clarify Solana quote-program feed path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@ Why use Switchboard? Our protocol is designed around 4 principles:
 * **Fastest Oracle Updates**
   * With latencies of 2-5ms with Surge, or 400ms with our standard oracles, no one beats Switchboard's speeds. In the fast-paced world of DeFi, faster price updates directly translate to increased security and higher returns.
 * **Low Costs**
-  * With pull feeds, feeds are created and used only when needed. This eliminates constant data streaming and _significantly_ reduces latency and costs.
+  * With on-demand feeds, feeds are created and used only when needed. This eliminates constant data streaming and _significantly_ reduces latency and costs.
 * **Permissionless and Flexible**
   * Deploy your new data feed, stream from any source on or off-chain, and set the exact parameters that you need. No need to wait for contracts or red tape.
 * **Secure and Private**
   * Switchboard prevents anyone, including node operators, from altering, exposing or frontrunning your data. Inside Trusted Execution Environments (TEEs), your code and data stay safe and secure.
 
 The Switchboard Protocol is [open-source](https://github.com/switchboard-xyz) and contributions are welcome. Need help using Switchboard? Our support team is available around the clock on [Discord](https://discord.gg/TJAv6ZYvPC).
-

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -9,6 +9,7 @@
   * [Price Feeds](docs-by-chain/solana-svm/price-feeds/README.md)
     * [Basic Price Feed Tutorial](docs-by-chain/solana-svm/price-feeds/basic-price-feed.md)
     * [Advanced Price Feed Tutorial](docs-by-chain/solana-svm/price-feeds/advanced-price-feed.md)
+    * [Quote Program Accounts](docs-by-chain/solana-svm/price-feeds/quote-program-accounts.md)
     * [Authority-Updated Feeds](docs-by-chain/solana-svm/price-feeds/authority-updated-feeds.md)
   * [Surge Price Feeds](docs-by-chain/solana-svm/surge/README.md)
     * [Surge Tutorial](docs-by-chain/solana-svm/surge/surge-tutorial.md)

--- a/ai-agents-llms/skills/switchboard-agent-skill.md
+++ b/ai-agents-llms/skills/switchboard-agent-skill.md
@@ -314,6 +314,11 @@ curl -sS "$CROSSBAR/simulate/$FEED_ID" | jq .
 
 ### Step 4: Run minimal Solana update+read transaction
 
+For new Solana/SVM feed-hash integrations, use managed quote-program updates
+and canonical quote accounts. Do not suggest `PullFeed.fetchUpdateIx(...)`
+unless the user is maintaining an existing classic PullFeed account and has
+confirmed queue/gateway support for that legacy path.
+
 ~~~ts
 import * as sb from "@switchboard-xyz/on-demand";
 import { OracleQuote } from "@switchboard-xyz/on-demand";

--- a/ai-agents-llms/skills/switchboard-solana-svm-feeds.md
+++ b/ai-agents-llms/skills/switchboard-solana-svm-feeds.md
@@ -45,6 +45,7 @@ This skill is about integration correctness, not designing new feed definitions 
 
 - Consumer instruction must occur after Switchboard verification/update instructions in the same transaction.
 - Use deterministic/canonical accounts; do not accept arbitrary “quote accounts” without canonical checks.
+- New feed-hash integrations use `queue.fetchManagedUpdateIxs(...)` and canonical quote-program accounts. Do not suggest `PullFeed.fetchUpdateIx(...)` unless the user is maintaining an existing classic PullFeed account and confirms queue/gateway support for that legacy path.
 - Variable overrides are secrets-only (never selectors/URLs/paths/IDs/multipliers).
 
 ## Minimal Example
@@ -191,6 +192,8 @@ Produce a `SolanaFeedIntegrationPlan` including:
 - Signature verification index mismatch → re-check `instructionIdx` vs final tx instruction order
 - Missing sysvars → include SlotHashes + Instructions sysvars in accounts
 - Non-canonical quote account → derive canonical address; reject non-canonical inputs
+- `pullFeedSubmitResponseConsensus` or `PullFeed.fetchUpdateIx(...)` returns `ORACLE_UNAVAILABLE`, but managed Ed25519 quote updates work → user is on the legacy PullFeed path; move to `queue.fetchManagedUpdateIxs(...)` and canonical quote accounts
+- Successful simulation but signed updates fail with `RangeExceeded` → feed validation issue; check raw v2 `maxJobRangePct` scaling separately from PullFeed-vs-quote-program routing
 - Compute limits → add compute budget ixs; reduce feeds/oracles per tx
 
 ## References

--- a/custom-feeds/advanced-feed-configuration/feed-parameter-units.md
+++ b/custom-feeds/advanced-feed-configuration/feed-parameter-units.md
@@ -40,3 +40,9 @@ const feed = {
 Use `maxJobRangePct: 0` only when the flow intentionally expects a single successful job/source or identical outputs. For normal multi-source feeds, set a positive scaled tolerance.
 
 Simulation can succeed even when signed updates fail. Simulation proves the jobs can resolve off-chain; signed updates also require oracle-side feed validation to pass. If update fetching returns `ORACLE_UNAVAILABLE` after successful simulation, inspect oracle errors for validation failures such as `RangeExceeded`, then check whether `maxJobRangePct` was scaled correctly.
+
+This feed-validation failure is separate from using the wrong Solana/SVM update
+path. If `PullFeed.fetchUpdateIx(...)` or `pullFeedSubmitResponseConsensus`
+returns `ORACLE_UNAVAILABLE` while `queue.fetchManagedUpdateIxs(...)` returns
+Ed25519 quote-program instructions, move the integration to canonical
+quote-program accounts; see [Quote Program Accounts](../../docs-by-chain/solana-svm/price-feeds/quote-program-accounts.md).

--- a/custom-feeds/build-and-deploy-feed/deploy-feed.md
+++ b/custom-feeds/build-and-deploy-feed/deploy-feed.md
@@ -43,6 +43,11 @@ On Solana, deployment means:
 
 The canonical account is created automatically on first use—no explicit initialization transaction required.
 
+For new Solana/SVM feed-hash integrations, this quote-program path is the
+supported default. Do not use `PullFeed.fetchUpdateIx(...)` unless you are
+maintaining an existing classic PullFeed account and the selected queue/gateway
+environment explicitly supports the legacy PullFeed update flow.
+
 ## Requirements
 
 - A funded Solana keypair file (payer)
@@ -118,6 +123,9 @@ const sig = await connection.sendTransaction(tx);
 console.log("Transaction signature:", sig);
 console.log("Feed deployed! Quote account:", quoteAccount.toBase58());
 ```
+
+To read the stored quote account, parse it with the SDK/Rust quote-account
+types instead of fixed byte offsets. See [Quote Program Accounts](../../docs-by-chain/solana-svm/price-feeds/quote-program-accounts.md).
 
 ### Using validation parameters
 

--- a/docs-by-chain/solana-svm/price-feeds/README.md
+++ b/docs-by-chain/solana-svm/price-feeds/README.md
@@ -8,4 +8,11 @@ This is where Data Feeds come in. Think of them as secure bridges connecting the
 
 - [Basic Price Feed Tutorial](basic-price-feed.md): Integrate managed, oracle-verified price feeds into a Solana program.
 - [Advanced Price Feed Tutorial](advanced-price-feed.md): Reduce compute costs with an authorized cranker pattern for oracle-backed quotes.
+- [Quote Program Accounts](quote-program-accounts.md): Derive and read canonical quote-program accounts without relying on fixed offsets.
 - [Authority-Updated Feeds](authority-updated-feeds.md): Publish quote accounts directly from a trusted wallet or PDA when your application is the source of truth.
+
+For new Solana/SVM feed-hash integrations, use the quote program:
+`queue.fetchManagedUpdateIxs(...)` writes canonical `OracleQuote` accounts
+derived from the queue and feed ID. The classic `PullFeed.fetchUpdateIx(...)`
+path is legacy compatibility only and requires queue/gateway support for classic
+PullFeed accounts.

--- a/docs-by-chain/solana-svm/price-feeds/advanced-price-feed.md
+++ b/docs-by-chain/solana-svm/price-feeds/advanced-price-feed.md
@@ -382,6 +382,11 @@ async function main() {
 }
 ```
 
+`OracleQuote.decode(...)` parses the Ed25519 quote instruction payload. Stored
+quote-program accounts are variable-length; read them with the Rust
+`SwitchboardQuote`/`PackedFeedInfo` account types instead of fixed offsets. See
+[Quote Program Accounts](quote-program-accounts.md).
+
 ## Running the Example
 
 ### 1. Clone the Examples Repository

--- a/docs-by-chain/solana-svm/price-feeds/basic-price-feed.md
+++ b/docs-by-chain/solana-svm/price-feeds/basic-price-feed.md
@@ -39,6 +39,11 @@ Every Switchboard oracle update requires two instructions in sequence:
 
 Your program then reads from this oracle account as a third instruction in the same transaction.
 
+This is the current path for new Solana/SVM feed-hash integrations. The older
+`PullFeed.fetchUpdateIx(...)` path writes classic PullFeed accounts and depends
+on queue/gateway support for that legacy flow. Use managed quote-program
+updates unless you are maintaining an existing classic PullFeed integration.
+
 ### Feed IDs
 
 Each price feed has a unique 32-byte hex identifier. You can find feed IDs in the [Switchboard Explorer](https://ondemand.switchboard.xyz/).
@@ -415,10 +420,22 @@ pub fn your_instruction(ctx: Context<YourInstruction>) -> Result<()> {
 }
 ```
 
+Quote accounts are variable-length. Do not read values by fixed byte offsets
+from one simulation result; parse them with `SwitchboardQuote` and
+`PackedFeedInfo`. See [Quote Program Accounts](quote-program-accounts.md).
+
+## Troubleshooting
+
+| Symptom | What it means |
+| --- | --- |
+| `pullFeedSubmitResponseConsensus` or `PullFeed.fetchUpdateIx(...)` returns `ORACLE_UNAVAILABLE`, but `queue.fetchManagedUpdateIxs(...)` returns Ed25519 + quote-program instructions | The integration is using the legacy PullFeed path against quote-program infrastructure. Use managed quote-program updates and read the canonical quote account. |
+| Simulation succeeds, but signed update fetching fails with oracle validation errors such as `RangeExceeded` | This is a feed validation issue, not a PullFeed-vs-quote-program issue. Check feed parameter units, especially raw v2 `maxJobRangePct`; see [Feed Parameter Units](../../../custom-feeds/advanced-feed-configuration/feed-parameter-units.md). |
+
 ## Next Steps
 
 - **Multiple Feeds**: Pass multiple feed IDs to `fetchManagedUpdateIxs` to update several prices in one transaction
 - **Staleness Checks**: Add maximum staleness requirements for your use case
+- **Quote Program Accounts**: Read canonical quote accounts safely in the [Quote Program Accounts](quote-program-accounts.md) guide
 - **Authority-Updated Feeds**: Publish quotes from your own trusted wallet or PDA in the [Authority-Updated Feeds](authority-updated-feeds.md) guide
 - **Custom Feeds**: Learn how to create custom data feeds in the [Custom Feeds](../../../custom-feeds/build-and-deploy-feed/README.md) section
 - **Advanced Patterns**: See the Advanced Price Feed tutorial for more complex integration patterns

--- a/docs-by-chain/solana-svm/price-feeds/quote-program-accounts.md
+++ b/docs-by-chain/solana-svm/price-feeds/quote-program-accounts.md
@@ -1,0 +1,74 @@
+# Quote Program Accounts
+
+Solana/SVM feed-hash integrations use canonical quote-program accounts. These
+accounts are derived from the queue public key and feed ID, then written by
+managed updates from `queue.fetchManagedUpdateIxs(...)`.
+
+Use this path for new custom feeds and feed-hash integrations. The older
+`PullFeed.fetchUpdateIx(...)` path targets classic PullFeed accounts and
+requires compatible legacy queue/gateway support.
+
+## Derive The Account
+
+```ts
+import { OracleQuote } from "@switchboard-xyz/on-demand";
+
+const [quoteAccount] = OracleQuote.getCanonicalPubkey(queue.pubkey, [feedId]);
+```
+
+The same feed ID and queue always derive the same quote account. If your
+program accepts a quote account, constrain it to the canonical address for the
+queue and feed ID.
+
+## Read Stored Data
+
+Stored quote accounts are variable-length. Do not parse feed values by
+hard-coding byte offsets from a simulation or one account instance.
+
+In Rust, use the SDK account types:
+
+- `SwitchboardQuote`: stored quote-program account
+- `PackedFeedInfo`: one feed result inside the quote
+- `feeds_slice()` / `feeds()`: access feed results
+- `feed_id` / `feed_id()`: 32-byte feed ID
+- `feed_value` / `feed_value()`: raw `i128` value, scaled by Switchboard precision
+- `value()`: decimal value helper
+- `min_oracle_samples` / `min_oracle_samples()`: oracle-sample quorum recorded with the feed
+
+```rust
+use switchboard_on_demand::QuoteVerifier;
+
+let quote = QuoteVerifier::new()
+    .queue(&ctx.accounts.queue)
+    .slothash_sysvar(&ctx.accounts.slothashes)
+    .ix_sysvar(&ctx.accounts.instructions)
+    .clock_slot(ctx.accounts.clock.slot)
+    .max_age(50)
+    .verify_account(&ctx.accounts.quote_account)?;
+
+for feed in quote.feeds() {
+    msg!("Feed {}: {}", feed.hex_id(), feed.value());
+}
+```
+
+## JavaScript Decode Scope
+
+`OracleQuote.decode(...)` parses the Ed25519 quote instruction payload used by
+managed updates. It is useful when inspecting a quote instruction before it is
+written on-chain.
+
+It is not a stable raw account decoder for stored quote-program account data.
+For stored account parsing, use the Rust/on-chain `SwitchboardQuote` account
+types until a dedicated JavaScript account decoder is available.
+
+## Troubleshooting
+
+If `queue.fetchManagedUpdateIxs(...)` returns Ed25519 + quote-program
+instructions but `PullFeed.fetchUpdateIx(...)` or
+`pullFeedSubmitResponseConsensus` returns `ORACLE_UNAVAILABLE`, the integration
+is using the classic PullFeed path against quote-program infrastructure. Move
+the integration to managed quote-program updates and canonical quote accounts.
+
+This is separate from feed-parameter scaling errors. If simulation succeeds but
+signed updates fail with oracle validation errors such as `RangeExceeded`, check
+the feed parameter units, especially raw v2 `maxJobRangePct`.

--- a/tooling/crossbar/README.md
+++ b/tooling/crossbar/README.md
@@ -20,13 +20,19 @@ Crossbar aims to streamline the Switchboard experience, offering the following c
 
 > Crossbar exposes both simulation and signed-update paths. Simulation can succeed even when signed updates fail oracle-side validation. For validation units such as raw v2 `maxJobRangePct` and gateway `max_variance`, see [Feed Parameter Units](../../custom-feeds/advanced-feed-configuration/feed-parameter-units.md).
 
+For current Solana/SVM feed-hash integrations, use the SDK managed update path
+(`queue.fetchManagedUpdateIxs(...)`) and canonical quote-program accounts. The
+classic `PullFeed.fetchUpdateIx(...)` and `/updates/solana/...` flows are
+legacy PullFeed compatibility paths and require queue/gateway support for that
+account scheme.
+
 ### Blockchain-Specific Features
 
 Crossbar provides tailored features for specific blockchains:
 
 **Solana and Aptos/Sui:**
 
-* **Fetch Encoded Update Instructions:** Retrieve update instructions from live oracles for Solana feeds (available on devnet and mainnet).
+* **Fetch Encoded Update Instructions:** Retrieve update instructions from live oracles. For Solana/SVM feed-hash integrations, prefer managed quote-program updates through the SDK; Crossbar's classic Solana update routes are for legacy PullFeed accounts.
 * **Fetch Simulated Results for Feeds:** Fetch current prices for feeds. This is a useful feature for tracking custom price feeds off-chain, for triggering an action that the bots can use.
 
 **Ethereum Virtual Machine (EVM):**

--- a/tooling/crossbar/api-endpoints.md
+++ b/tooling/crossbar/api-endpoints.md
@@ -31,6 +31,10 @@ For machine-readable schema and live testing:
 
 Parameter units are surface-specific. Raw v2 `OracleFeed.maxJobRangePct` and raw gateway `max_variance` values are percentages scaled by `1e9`; `1_000_000_000` means `1%`. See [Feed Parameter Units](../../custom-feeds/advanced-feed-configuration/feed-parameter-units.md).
 
+Use `/v2/fetch/{feed_id}` for v2 feed IDs created by Feed Builder or
+Crossbar v2 storage. The older `/fetch/{hash}` route is for v1 feed definitions
+and legacy compatibility.
+
 ## EVM Route Selection
 
 Use different Crossbar routes depending on whether you are integrating a current Feed Builder/custom feed or an older aggregator-based EVM integration.
@@ -39,6 +43,18 @@ Use different Crossbar routes depending on whether you are integrating a current
 | --- | --- | --- | --- |
 | Feed Builder/custom feed on EVM | `/v2/fetch/{feed_id}`, `/v2/simulate/{feedHashes}`, `/v2/update/{feedHashes}` | deterministic `bytes32` feed ID / feed hash | Recommended flow for Monad and current custom-feed integrations. Use `chain=evm`, `network=mainnet|testnet`, and usually `use_timestamp=true` on `/v2/update`. |
 | Legacy aggregator-based EVM integration | `/simulate/evm/{network}/{aggregator_ids}`, `/updates/evm/{chainId}/{aggregatorIds}` | legacy aggregator ID | Compatibility flow for older EVM integrations. Do not use this as the primary path for Feed Builder custom feeds. |
+
+## Solana/SVM Route Selection
+
+For new Solana/SVM feed-hash integrations, prefer the SDK managed update path:
+`queue.fetchManagedUpdateIxs(...)`. It fetches Ed25519 oracle signatures and
+builds the quote-program `verified_update` instruction that writes the
+canonical `OracleQuote` account.
+
+The classic `PullFeed.fetchUpdateIx(...)` and Crossbar `/updates/solana/...`
+flows target legacy PullFeed accounts and `pullFeedSubmitResponseConsensus`.
+Use them only for existing classic PullFeed integrations where the selected
+queue/gateway environment supports that path.
 
 ## Simulation Endpoints
 


### PR DESCRIPTION
## Summary
- add a Solana/SVM quote-program accounts page documenting canonical OracleQuote derivation and stored account parsing guidance
- add callouts from feed, Crossbar, and AI-agent docs that new feed-hash integrations use queue.fetchManagedUpdateIxs and canonical quote accounts
- document ORACLE_UNAVAILABLE troubleshooting for using legacy PullFeed updates against quote-program infrastructure, separate from maxJobRangePct scaling issues

## Verification
- user-docs boundary scanner passed for touched Markdown
- search audit completed for PullFeed/quote-program/current-path wording
- git diff --check passed
- no live devnet/gateway/transaction test run