### PR TITLE
Document Pyth and Jupiter API key overrides

### DIFF
--- a/.github/workflows/sync-task-types.yml
+++ b/.github/workflows/sync-task-types.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Test task documentation generator
+        run: node --test scripts/generate-task-docs.test.js
+
       - name: Generate task documentation
         run: node scripts/generate-task-docs.js
 

--- a/custom-feeds/advanced-feed-configuration/data-feed-variable-overrides.md
+++ b/custom-feeds/advanced-feed-configuration/data-feed-variable-overrides.md
@@ -1,761 +1,124 @@
 ---
-description: >-
-  Using variable overrides in data feeds for dynamic configuration and secure
-  API integration
+description: Configure request-scoped values in oracle jobs without hardcoding credentials.
 ---
 
 # Data Feed Variable Overrides
 
-Variable overrides provide a powerful mechanism for dynamically configuring oracle jobs without hardcoding sensitive information like API keys or frequently changing parameters. This feature enables secure, flexible data feed configuration for both testing and production environments.
+Variable overrides substitute request-scoped values into string fields in an oracle job. Put a placeholder such as `${MARKET_DATA_API_KEY}` in the job definition, then provide the matching non-empty value in `variableOverrides` when requesting execution.
 
-## What are Variable Overrides?
+Overrides are a general substitution feature. They can represent credentials, URLs, symbols, paths, headers, query parameters, or other string values. Whether a particular override is appropriate depends on who controls updates and what feed consumers trust.
 
-Variable overrides allow you to inject values into oracle job definitions at runtime using the `${VARIABLE_NAME}` syntax.
+## Trust Model
 
-## Security Warning: Variables Are Not Verifiable
+The concrete override map is execution-scoped. It is not included in the feed ID or the signed checksum. A consumer can identify the job definition containing `${VARIABLE_NAME}`, but cannot recover or independently verify the value substituted for that placeholder from the feed identity or signature.
 
-Variable overrides are **not part of the cryptographic verification process**. The oracle signatures only verify the job structure, not the variable values injected at runtime. This means:
+TEE-backed execution protects how selected oracle software handles a request, but it does not make override values part of the feed definition. The execution nodes necessarily receive values that their tasks must use, so credentials should be scoped to the intended API and request path.
 
-* Variables can be manipulated by whoever controls the execution environment
-* Feed consumers cannot verify what variable values were used
-* Use variables only for authentication (API keys and tokens)
-* Never use variables for URLs, paths, parameters, calculations, or data selection logic
+Choose override values according to the update model:
 
-### Safe Uses
+| Update model | Appropriate use |
+| --- | --- |
+| Permissionless feed updates | Prefer credentials and other values that do not intentionally change the data source, selected market, extraction path, or calculation. Keep semantic inputs fixed in the job definition. |
+| Controlled updater | Semantic values such as a URL, symbol, or path are supported when the caller controls every execution request and consumers intentionally trust that caller to select them. |
 
-* API keys: `${API_KEY}`
-* Authentication tokens: `${AUTH_TOKEN}`
+One execution request should represent one customer or security domain. Do not combine unrelated customers' jobs and credentials in one request.
 
-### Unsafe Uses
+## Credential Example
 
-* Base URLs: `${BASE_URL}` (changes data source)
-* API versions: `${API_VERSION}` (could return different data formats)
-* Price multipliers: `${MULTIPLIER}` (affects calculations)
-* JSON paths: `${JSON_PATH}` (changes what data is extracted)
-* Any parameter that affects data traversal, extraction, or calculation
-
-## Primary Use Case: Secure Credential Management
-
-The main purpose of variable overrides is to keep sensitive credentials out of job definitions while maintaining feed verifiability:
-
-* **Secure API Key Management**: Keep sensitive credentials out of job definitions
-* **Environment-Specific Authentication**: Use different tokens for testing vs production
-
-## Basic Syntax
-
-Variables in oracle jobs use the template syntax `${VARIABLE_NAME}` and are replaced at execution time:
+Keep the data source and extraction logic fixed while substituting only the credential:
 
 ```typescript
-// In your oracle job definition
-{
-  httpTask: {
-    url: "https://api.example.com/v1/btc-price?key=${API_KEY}",  // Hardcoded symbol
-    method: "GET"
-  }
+const apiKey = process.env.MARKET_DATA_API_KEY;
+if (!apiKey) {
+  throw new Error("MARKET_DATA_API_KEY is required");
 }
-```
 
-```typescript
-// When fetching signatures, provide the overrides
-import { OracleJob, CrossbarClient } from "@switchboard-xyz/common";
-import * as sb from "@switchboard-xyz/on-demand";
-
-const { program } = await sb.AnchorUtils.loadEnv();
-const queue = await sb.Queue.loadDefault(program!);
-const crossbar = new CrossbarClient("http://crossbar.switchboard.xyz");
-const gateway = await queue.fetchGatewayFromCrossbar(crossbar);
-
-const res = await queue.fetchSignaturesConsensus({
-  gateway,
-  feedConfigs: [{
-    feed: {
-      jobs: [yourJob],
+const job = {
+  tasks: [
+    {
+      httpTask: {
+        url: "https://api.example.com/v1/markets/BTC-USD/price",
+        headers: [
+          {
+            key: "authorization",
+            value: "Bearer ${MARKET_DATA_API_KEY}",
+          },
+        ],
+      },
     },
-  }],
-  numSignatures: 1,
-  useEd25519: true,
+    {
+      jsonParseTask: {
+        path: "$.price",
+      },
+    },
+  ],
+};
+
+const response = await gateway.fetchSignaturesConsensus({
+  // ...feed request fields containing job
   variableOverrides: {
-    "API_KEY": process.env.API_KEY!  // Only authentication
+    MARKET_DATA_API_KEY: apiKey,
   },
 });
 ```
 
-## Common Use Cases
+Placeholder names are case-sensitive and must match the map key exactly. Use environment variables or a secret manager as the source of credential values. Never hardcode credentials in a job, commit them, include them in errors, or log override values.
 
-### 1. API Authentication
+## Semantic Overrides
 
-Secure API integration using environment variables:
+Semantic overrides are valid for a controlled caller. For example, a backend that owns the request and whose consumers trust its market selection can use:
 
 ```typescript
-function getPolygonStockJob(): OracleJob {
-  const job = OracleJob.fromObject({
-    tasks: [
-      {
-        httpTask: {
-          url: "https://api.polygon.io/v2/last/trade/AAPL?apiKey=${POLYGON_API_KEY}",  // Hardcoded symbol
-          method: "GET",
-        }
+const job = {
+  tasks: [
+    {
+      httpTask: {
+        url: "https://api.example.com/v1/markets/${MARKET}/price",
       },
-      {
-        jsonParseTask: {
-          path: "$.results.p",
-        }
-      }
-    ]
-  });
-  return job;
-}
+    },
+    {
+      jsonParseTask: {
+        path: "$.price",
+      },
+    },
+  ],
+};
 
-// Usage with variable overrides
-const res = await queue.fetchSignaturesConsensus({
-  // ... other config
+const response = await gateway.fetchSignaturesConsensus({
+  // ...feed request fields containing job
   variableOverrides: {
-    "POLYGON_API_KEY": process.env.POLYGON_API_KEY!  // Only API key
+    MARKET: "BTC-USD",
   },
 });
 ```
 
-### 2. Recommended: API Key Only Usage
+This request can produce a different result for each `MARKET` value while retaining the same feed identity. Do not use this pattern on a permissionless update path where an untrusted updater could select the value.
 
-The safest and recommended approach - only use variables for API keys:
+## Jupiter and Pyth API Keys
 
-```typescript
-function getSecurePriceJob(): OracleJob {
-  const job = OracleJob.fromObject({
-    tasks: [
-      {
-        httpTask: {
-          // Everything hardcoded except API key
-          url: "https://api.coinbase.com/v2/exchange-rates?currency=BTC&apikey=${API_KEY}",
-          method: "GET"
-        }
-      },
-      {
-        jsonParseTask: {
-          // Hardcoded path - verifiable data extraction
-          path: "$.data.rates.USD",
-        }
-      }
-    ]
-  });
-  return job;
-}
+Jupiter and Pyth both support customer-provided API keys, but their fallback rules differ:
 
-// Usage - ONLY API key as variable
-variableOverrides: {
-  "API_KEY": process.env.COINBASE_API_KEY!  // Only credential management
-}
-```
+| Task | Preferred task field | Override behavior |
+| --- | --- | --- |
+| JupiterSwapTask | `apiKey: "${JUPITER_API_KEY}"` | `JUPITER_API_KEY` is a conventional example name, not reserved. The override is applied only when the field contains the matching placeholder. An unresolved placeholder fails before contacting Jupiter. If the field is omitted or empty, the oracle's configured Jupiter key is used when available. |
+| OracleTask with `pythAddress` | `pythConfigs.apiKey: "${PYTH_API_KEY}"` | A non-empty task field takes precedence. If it is omitted or empty, the reserved request override `PYTH_API_KEY` is a compatibility fallback for every eligible `pythAddress` task in that request. The fallback is not shared with another request or customer. |
+| OracleTask with `pythPushFeedId` | None | The task reads an on-chain account and does not use Hermes authentication. |
 
-### 3. Multiple API Authentication Headers
+For new Pyth feed definitions, use the explicit task placeholder. The request-wide `PYTH_API_KEY` fallback exists so existing `pythAddress` jobs can adopt authenticated Hermes access without changing each stored job during the Pyth Core transition.
 
-When you need multiple authentication parameters:
+See [Jupiter API keys](decentralized-exchanges.md#jupiter-exchange-aggregator), [Pyth authentication and push feeds](oracle-aggregator.md#pyth), [JupiterSwapTask](../task-types.md#jupiterswaptask), and [OracleTask](../task-types.md#oracletask) for task-specific examples and fields.
 
-```typescript
-function getMultiAuthJob(): OracleJob {
-  const job = OracleJob.fromObject({
-    tasks: [
-      {
-        httpTask: {
-          // Hardcoded endpoint and path - verifiable
-          url: "https://api.example.com/v1/btc-price",
-          method: "GET",
-          headers: [
-            {
-              key: "Authorization",
-              value: "Bearer ${AUTH_TOKEN}"  // Auth only
-            },
-            {
-              key: "X-API-Key", 
-              value: "${API_KEY}"           // Auth only
-            }
-          ]
-        }
-      },
-      {
-        jsonParseTask: {
-          // Hardcoded path - verifiable data extraction
-          path: "$.price",
-        }
-      }
-    ]
-  });
-  return job;
-}
+## Operational Guidance
 
-// Usage - only authentication credentials as variables
-variableOverrides: {
-  "AUTH_TOKEN": process.env.BEARER_TOKEN!,
-  "API_KEY": process.env.API_KEY!
-}
-```
-
-### 4. Simple Value Substitution
-
-For testing or static value injection:
-
-```typescript
-function getValueJob(): OracleJob {
-  const job = OracleJob.fromObject({
-    tasks: [
-      {
-        valueTask: {
-          big: "${VALUE}",
-        },
-      },
-    ],
-  });
-  return job;
-}
-
-// Usage for testing
-variableOverrides: {
-  "VALUE": "12345.67"
-}
-```
-
-## Variable Override Patterns
-
-> Only use variables for API keys and authentication tokens. Everything else should be hardcoded to ensure feed verifiability.
-
-### HTTP Headers with Authentication (Recommended Pattern)
-
-```typescript
-{
-  httpTask: {
-    url: "https://api.specificprovider.com/v1/btc-usd",  // Hardcoded endpoint
-    method: "GET",
-    headers: [
-      {
-        key: "Authorization",
-        value: "Bearer ${ACCESS_TOKEN}"  // Only auth token variable
-      },
-      {
-        key: "X-API-Key",
-        value: "${API_KEY}"             // Only API key variable
-      },
-      {
-        key: "User-Agent",
-        value: "Switchboard-Oracle/1.0"  // Hardcoded
-      }
-    ]
-  }
-}
-```
-
-### POST Request Bodies (Auth Only)
-
-```typescript
-{
-  httpTask: {
-    url: "https://api.specificprovider.com/v1/query",  // Hardcoded
-    method: "POST",
-    headers: [
-      {
-        key: "Content-Type",
-        value: "application/json"
-      }
-    ],
-    // Only API key as variable, symbol hardcoded and verifiable
-    body: '{"symbol": "BTCUSD", "apiKey": "${API_KEY}"}'
-  }
-}
-```
-
-### JSON Paths (No Variables Recommended)
-
-```typescript
-{
-  jsonParseTask: {
-    // Completely hardcoded path - fully verifiable
-    path: "$.data.price_usd"
-  }
-}
-
-// Don't do this - affects data extraction:
-// path: "$.${ROOT_KEY}.${DATA_KEY}[${INDEX}].${FIELD}"
-```
-
-## Testing and Development Workflow
-
-### 1. Local Development Script
-
-Create a testing script similar to the example:
-
-```typescript
-// scripts/test-job.ts
-import { OracleJob, CrossbarClient } from "@switchboard-xyz/common";
-import * as sb from "@switchboard-xyz/on-demand";
-
-// Insecure example - do not use in production
-// This example violates security warnings and is for educational purposes only
-function getDangerousJob(): OracleJob {
-  // WARNING: This pattern is NOT RECOMMENDED
-  // Variables for URLs and paths make feeds unverifiable
-  const job = OracleJob.fromObject({
-    tasks: [
-      {
-        httpTask: {
-          url: "${BASE_URL}/api/data?key=${API_KEY}&symbol=${SYMBOL}",  // Unverifiable
-          method: "GET",
-        }
-      },
-      {
-        jsonParseTask: {
-          path: "${JSON_PATH}",  // Unverifiable data extraction
-        }
-      }
-    ]
-  });
-  return job;
-}
-
-// RECOMMENDED SECURE VERSION
-function getSecureJob(): OracleJob {
-  const job = OracleJob.fromObject({
-    tasks: [
-      {
-        httpTask: {
-          url: "https://api.coinbase.com/v2/exchange-rates?currency=BTC&key=${API_KEY}",  // Hardcoded
-          method: "GET",
-        }
-      },
-      {
-        jsonParseTask: {
-          path: "$.data.rates.USD",  // Hardcoded path
-        }
-      }
-    ]
-  });
-  return job;
-}
-
-(async function main() {
-  const { program } = await sb.AnchorUtils.loadEnv();
-  const queue = await sb.Queue.loadDefault(program!);
-  const crossbar = new CrossbarClient("http://crossbar.switchboard.xyz");
-  const gateway = await queue.fetchGatewayFromCrossbar(crossbar);
-  
-  // Insecure - uses unverifiable job
-  const dangerousRes = await queue.fetchSignaturesConsensus({
-    gateway,
-    feedConfigs: [{
-      feed: {
-        jobs: [getDangerousJob()],  // Not recommended
-      },
-    }],
-    numSignatures: 1,
-    useEd25519: true,
-    variableOverrides: {
-      "BASE_URL": process.env.BASE_URL!,      // Unverifiable
-      "API_KEY": process.env.API_KEY!,        // OK for auth
-      "SYMBOL": process.env.SYMBOL || "BTC",  // Data selection
-      "JSON_PATH": process.env.JSON_PATH || "$.price"  // Data extraction
-    },
-  });
-  
-  // RECOMMENDED - Uses secure job
-  const secureRes = await queue.fetchSignaturesConsensus({
-    gateway,
-    feedConfigs: [{
-      feed: {
-        jobs: [getSecureJob()],  // Secure and verifiable
-      },
-    }],
-    numSignatures: 1,
-    useEd25519: true,
-    variableOverrides: {
-      "API_KEY": process.env.API_KEY!  // Only authentication
-    },
-  });
-  
-  console.log("Oracle responses:", res.median_responses);
-})();
-```
-
-### 2. Running Tests
-
-```bash
-# Not recommended - testing with unverifiable variables
-# BASE_URL=https://api.example.com \
-# API_KEY=your_api_key_here \
-# SYMBOL=BTC \
-# JSON_PATH=$.result.price \
-# bun run scripts/test-job.ts
-
-# Recommended - testing with only auth variables
-API_KEY=your_api_key_here bun run scripts/test-job.ts
-```
-
-### 3. Environment File Approach
-
-```bash
-# Not recommended .env setup
-# echo "BASE_URL=https://api.example.com" >> .env  # Unverifiable
-# echo "SYMBOL=BTC" >> .env                        # Data selection
-# echo "JSON_PATH=$.result.price" >> .env         # Data extraction
-
-# Recommended .env setup - only authentication
-echo "API_KEY=your_api_key_here" >> .env
-echo "AUTH_TOKEN=your_auth_token" >> .env
-
-# Load automatically with dotenv
-bun run scripts/test-job.ts
-```
-
-## Security Best Practices
-
-### 1. Never Hardcode Secrets
-
-**Don't do this:**
-
-```typescript
-variableOverrides: {
-  "API_KEY": "sk_1234567890abcdef", // Hardcoded secret
-}
-```
-
-**Do this instead:**
-
-```typescript
-variableOverrides: {
-  "API_KEY": process.env.API_KEY!, // From environment
-}
-```
-
-### 2. Validate Required Variables
-
-```typescript
-function validateEnvironment() {
-  const required = ['API_KEY', 'BASE_URL'];
-  for (const key of required) {
-    if (!process.env[key]) {
-      throw new Error(`Missing required environment variable: ${key}`);
-    }
-  }
-}
-
-// Call before using overrides
-validateEnvironment();
-```
-
-### 3. Use Different Keys for Different Environments
-
-```bash
-# Development
-DEV_API_KEY=dev_key_here
-
-# Production  
-PROD_API_KEY=prod_key_here
-```
-
-```typescript
-const apiKey = process.env.NODE_ENV === 'production' 
-  ? process.env.PROD_API_KEY 
-  : process.env.DEV_API_KEY;
-
-variableOverrides: {
-  "API_KEY": apiKey!
-}
-```
-
-## Error Handling and Debugging
-
-### Common Issues
-
-#### 1. Missing Variables
-
-```bash
-Error: Cannot read property 'undefined' of process.env
-```
-
-**Solution:** Ensure all referenced variables are defined:
-
-```bash
-# Check what variables your job needs
-grep '\${' your-job-file.ts
-
-# Set missing variables
-export MISSING_VAR=value
-```
-
-#### 2. Incorrect Variable Names
-
-Variables are case-sensitive and must match exactly:
-
-```typescript
-// Job definition uses
-url: "${API_KEY}"
-
-// Override must use same case
-variableOverrides: {
-  "API_KEY": "value" // Correct
-  "api_key": "value" // Wrong case
-}
-```
-
-#### 3. JSON Path Issues
-
-When using variables in JSON paths, ensure the resulting path is valid:
-
-```typescript
-// This creates: "$.data.undefined.price" if FIELD is not set
-path: "$.data.${FIELD}.price"
-
-// Better: provide defaults
-variableOverrides: {
-  "FIELD": process.env.FIELD || "defaultField"
-}
-```
-
-### Debugging Tips
-
-1. **Log Variable Overrides**
-
-```typescript
-console.log("Variable overrides:", {
-  ...Object.fromEntries(
-    Object.entries(variableOverrides).map(([k, v]) => 
-      [k, k.includes('KEY') || k.includes('TOKEN') ? '***' : v]
-    )
-  )
-});
-```
-
-2. **Test API Endpoints Manually**
-
-```bash
-# Test your API endpoint with curl
-curl "https://api.example.com/v1/data?key=YOUR_KEY"
-```
-
-3. **Validate JSON Paths**
-
-```bash
-# Test JSON path extraction
-curl "your_api_endpoint" | jq "$.path.you.want"
-```
-
-## Real-World Examples
-
-### Example 1: Polygon.io Stock Prices
-
-Get stock prices from Polygon.io API with secure API key management:
-
-```typescript
-import { OracleJob, CrossbarClient } from "@switchboard-xyz/common";
-import * as sb from "@switchboard-xyz/on-demand";
-
-function getPolygonStockJob(): OracleJob {
-  const job = OracleJob.fromObject({
-    tasks: [
-      {
-        httpTask: {
-          // Hardcoded endpoint and symbol - verifiable data source
-          url: "https://api.polygon.io/v2/last/trade/AAPL?apiKey=${POLYGON_API_KEY}",
-          method: "GET",
-        }
-      },
-      {
-        jsonParseTask: {
-          // Hardcoded path - verifiable data extraction
-          path: "$.results.p",
-        }
-      }
-    ]
-  });
-  return job;
-}
-
-// Usage with secure API key management
-const { program } = await sb.AnchorUtils.loadEnv();
-const queue = await sb.Queue.loadDefault(program!);
-const crossbar = new CrossbarClient("http://crossbar.switchboard.xyz");
-const gateway = await queue.fetchGatewayFromCrossbar(crossbar);
-
-const res = await queue.fetchSignaturesConsensus({
-  gateway,
-  feedConfigs: [{
-    feed: {
-      jobs: [getPolygonStockJob()],
-    },
-  }],
-  numSignatures: 1,
-  useEd25519: true,
-  variableOverrides: {
-    "POLYGON_API_KEY": process.env.POLYGON_API_KEY!,  // Only API key
-  },
-});
-```
-
-### Example 2: ESPN Sports Scores
-
-Get NFL final scores from ESPN API:
-
-```typescript
-import { OracleJob, CrossbarClient } from "@switchboard-xyz/common";
-import * as sb from "@switchboard-xyz/on-demand";
-
-function getESPNFootballScoreJob(): OracleJob {
-  const job = OracleJob.fromObject({
-    tasks: [
-      {
-        httpTask: {
-          // Hardcoded specific game endpoint
-          url: "https://site.api.espn.com/apis/site/v2/sports/football/nfl/scoreboard/401547439?apikey=${ESPN_API_KEY}",
-          method: "GET",
-        }
-      },
-      {
-        jsonParseTask: {
-          // Hardcoded path to home team final score
-          path: "$.events[0].competitions[0].competitors[0].score",
-        }
-      }
-    ]
-  });
-  return job;
-}
-
-// Usage
-const { program } = await sb.AnchorUtils.loadEnv();
-const queue = await sb.Queue.loadDefault(program!);
-const crossbar = new CrossbarClient("http://crossbar.switchboard.xyz");
-const gateway = await queue.fetchGatewayFromCrossbar(crossbar);
-
-const res = await queue.fetchSignaturesConsensus({
-  gateway,
-  feedConfigs: [{
-    feed: {
-      jobs: [getESPNFootballScoreJob()],
-    },
-  }],
-  numSignatures: 1,
-  useEd25519: true,
-  variableOverrides: {
-    "ESPN_API_KEY": process.env.ESPN_API_KEY!,  // Only API key
-  },
-});
-```
-
-### Example 3: Twitter Follower Count
-
-Get follower count for a specific Twitter account:
-
-```typescript
-import { OracleJob, CrossbarClient } from "@switchboard-xyz/common";
-import * as sb from "@switchboard-xyz/on-demand";
-
-function getTwitterFollowersJob(): OracleJob {
-  const job = OracleJob.fromObject({
-    tasks: [
-      {
-        httpTask: {
-          // Hardcoded user ID - verifiable target account
-          url: "https://api.twitter.com/2/users/783214",  // Twitter's official account
-          method: "GET",
-          headers: [
-            {
-              key: "Authorization",
-              value: "Bearer ${TWITTER_BEARER_TOKEN}"  // Only auth token
-            }
-          ]
-        }
-      },
-      {
-        jsonParseTask: {
-          // Hardcoded path to follower count
-          path: "$.data.public_metrics.followers_count",
-        }
-      }
-    ]
-  });
-  return job;
-}
-
-// Usage
-const { program } = await sb.AnchorUtils.loadEnv();
-const queue = await sb.Queue.loadDefault(program!);
-const crossbar = new CrossbarClient("http://crossbar.switchboard.xyz");
-const gateway = await queue.fetchGatewayFromCrossbar(crossbar);
-
-const res = await queue.fetchSignaturesConsensus({
-  gateway,
-  feedConfigs: [{
-    feed: {
-      jobs: [getTwitterFollowersJob()],
-    },
-  }],
-  numSignatures: 1,
-  useEd25519: true,
-  variableOverrides: {
-    "TWITTER_BEARER_TOKEN": process.env.TWITTER_BEARER_TOKEN!,  // Only auth token
-  },
-});
-```
-
-### Key Principles in These Examples
-
-1. **Hardcoded Data Sources**: URLs specify exact endpoints and parameters
-2. **Hardcoded Data Paths**: JSON paths are fixed, ensuring consistent data extraction
-3. **Authentication Only Variables**: Only API keys and tokens use variable substitution
-4. **Verifiable Logic**: Feed consumers can verify exactly what data is being fetched and how
-
-### Environment Setup for Examples
-
-```bash
-# Create .env file with your API keys
-echo "POLYGON_API_KEY=your_polygon_key_here" >> .env
-echo "ESPN_API_KEY=your_espn_key_here" >> .env
-echo "TWITTER_BEARER_TOKEN=your_twitter_token_here" >> .env
-```
-
-```bash
-# Run examples
-POLYGON_API_KEY=your_key bun run scripts/job-testing/runJob.ts
-ESPN_API_KEY=your_key bun run scripts/job-testing/runJob.ts
-TWITTER_BEARER_TOKEN=your_token bun run scripts/job-testing/runJob.ts
-```
-
-## Integration with Production Systems
-
-### Oracle Quotes Integration
-
-When using variable overrides with Oracle Quotes:
-
-```typescript
-// Client-side: fetch Oracle Quote with variable overrides
-const [sigVerifyIx, oracleQuote] = await queue.fetchUpdateQuoteIx(
-  gateway,
-  crossbar,
-  feedHashes,
-  {
-    variableOverrides: {
-      "API_KEY": process.env.API_KEY!,
-      "AUTH_TOKEN": process.env.AUTH_TOKEN!
-    }
-  }
-);
-
-// Use in your Solana program
-const tx = await asV0Tx({
-  connection,
-  ixs: [sigVerifyIx, yourProgramIx],
-  signers: [wallet],
-});
-```
-
-### Production Considerations
-
-1. **Secret Management**: Use secure secret management systems
-2. **Variable Validation**: Implement runtime validation
-3. **Fallback Values**: Provide sensible defaults where appropriate
-4. **Monitoring**: Log variable usage for debugging (without exposing secrets)
-5. **Documentation**: Clearly document required variables for each job
+* Validate that every required override is present and non-empty before sending the request.
+* Use least-privilege, rate-limited credentials and rotate them through your secret manager.
+* Log placeholder names or whether configuration is present, never override values.
+* Keep one customer's jobs and credentials within that customer's execution request.
+* For permissionless feeds, keep the endpoint, selected data, parsing path, and calculations fixed in the job definition.
 
 ## Related Resources
 
-* [Variables with CacheTask](variables-with-cachetask.md) - For internal variable management
-* [REST APIs with HttpTask](rest-apis-with-httptask.md) - HTTP request configuration
-* [Build with TypeScript](../build-and-deploy-feed/build-with-typescript.md) - Oracle Jobs, simulation, and task composition
-* [Task Types Reference](../task-types.md) - Full task reference and examples
+* [REST APIs with HttpTask](rest-apis-with-httptask.md)
+* [Variables with CacheTask](variables-with-cachetask.md)
+* [Build with TypeScript](../build-and-deploy-feed/build-with-typescript.md)
+* [Task Types Reference](../task-types.md)

--- a/custom-feeds/advanced-feed-configuration/decentralized-exchanges.md
+++ b/custom-feeds/advanced-feed-configuration/decentralized-exchanges.md
@@ -8,16 +8,32 @@ description: Some common tasks relating to Decentralized Exchanges and DeFi.
 
 Users can fetch data from the [Jupiter Exchange Aggregator](https://jup.ag/). This can be an effective tool for quoting assets traded on Solana.
 
-```
+```typescript
 // KMNO/USD with 2% slippage
 {
-    jupiterSwapTask: {
-        inTokenAddress: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // USDC
-        outTokenAddress: "KMNo3nJsBXfcpJTVhZcXLW7RmTwTt4GVFE7suUBo9sS", // KMNO
-        slippage: 2.0
-    }
+  jupiterSwapTask: {
+    inTokenAddress: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // USDC
+    outTokenAddress: "KMNo3nJsBXfcpJTVhZcXLW7RmTwTt4GVFE7suUBo9sS", // KMNO
+    slippage: 2.0,
+    apiKey: "${JUPITER_API_KEY}",
+  },
 }
 ```
+
+Supply the matching non-empty value with the execution request:
+
+```typescript
+const response = await gateway.fetchSignaturesConsensus({
+  // ...feed request fields
+  variableOverrides: {
+    JUPITER_API_KEY: process.env.JUPITER_API_KEY!,
+  },
+});
+```
+
+`JUPITER_API_KEY` is a conventional name, not a reserved fallback. The override key must exactly match the placeholder in `apiKey`. If the placeholder is unresolved, the task fails before contacting Jupiter. If `apiKey` is omitted or empty, the task uses the oracle's configured Jupiter API key when one is available.
+
+Do not hardcode an API key in the job definition. See [Data Feed Variable Overrides](data-feed-variable-overrides.md) for request scope and trust-boundary guidance, [Pyth authentication](oracle-aggregator.md#pyth) for its different compatibility fallback, and the [JupiterSwapTask reference](../task-types.md#jupiterswaptask) for every field.
 
 ## **Raydium**
 
@@ -39,7 +55,9 @@ The following is an example using Raydium to quote [SLERF/SOL](https://dexscreen
         {
           oracleTask: {
             pythAddress: "H6ARHf6YXhGYeQfUzQNGk6rDNnLBQKrenN712K4AQJEG", // SOL/USD
-            pythAllowedConfidenceInterval: 1.2,
+            pythConfigs: {
+              pythAllowedConfidenceInterval: 1.2,
+            },
           }
         }
       ]

--- a/custom-feeds/advanced-feed-configuration/oracle-aggregator.md
+++ b/custom-feeds/advanced-feed-configuration/oracle-aggregator.md
@@ -6,19 +6,62 @@ description: Switchboard can fetch data from a number of oracles. Here's how to 
 
 ## Pyth
 
-The [Pyth Oracle Network](https://pyth.network/) provides a over [500 data feeds](https://pyth.network/developers/price-feed-ids) that you can read through the Switchboard Oracle Aggregator task.
+The [Pyth Oracle Network](https://pyth.network/) publishes [price feeds](https://pyth.network/developers/price-feed-ids) that the Oracle Aggregator task can read through Hermes or from an on-chain Solana push-feed account. The two paths have different authentication and freshness behavior.
 
-Here's an example of the Pyth oracle task, being used to pull the price of [SNX/USD](https://pyth.network/price-feeds/crypto-snx-usd):
+### Hermes-backed feeds with `pythAddress`
 
-```
-// SNX/USD Task with accepted confidence interval of 1.2%
+Use `pythAddress` for the Hermes-backed path. It accepts existing Pyth Solana price account addresses and Pyth price-feed IDs. For authenticated Hermes access, place an API-key placeholder in `pythConfigs.apiKey`:
+
+```typescript
+// SNX/USD with a 1.2% maximum confidence interval
 {
-    oracleTask: {
-        pythAddress: "0x39d020f60982ed892abbcd4a06a276a9f9b7bfbce003204c110b6e488f502da3",
-        pythAllowedConfidenceInterval: 1.2,
+  oracleTask: {
+    pythAddress: "0x39d020f60982ed892abbcd4a06a276a9f9b7bfbce003204c110b6e488f502da3",
+    pythConfigs: {
+      apiKey: "${PYTH_API_KEY}",
+      pythAllowedConfidenceInterval: 1.2,
+      maxStaleSeconds: 15,
     },
+  },
 }
 ```
+
+Provide the key on the same execution request:
+
+```typescript
+const response = await gateway.fetchSignaturesConsensus({
+  // ...feed request fields
+  variableOverrides: {
+    PYTH_API_KEY: process.env.PYTH_API_KEY!,
+  },
+});
+```
+
+For new feed definitions, prefer an explicit `pythConfigs.apiKey` placeholder. It makes the task's credential dependency visible and allows different Pyth tasks in one request to name different keys. After placeholder expansion, a non-empty task-level `apiKey` takes precedence.
+
+Existing `pythAddress` jobs do not need to be rewritten during the Pyth Core transition. When `pythConfigs.apiKey` is omitted or empty, the task accepts the reserved request override `PYTH_API_KEY` as a compatibility fallback. One fallback value covers every `pythAddress` task in that execution request that does not set its own `apiKey`; it does not apply to other requests or become an oracle-wide key. This preserves existing feed definitions while allowing the customer making the request to pay for its Hermes calls.
+
+The compatibility fallback assumes one execution request belongs to one customer or security domain. Do not combine unrelated customers' jobs and credentials in a single request.
+
+### On-chain push feeds with `pythPushFeedId`
+
+Use `pythPushFeedId` for an upgraded Solana push feed. This path derives and reads the on-chain price account; it does not call Hermes and does not use a Hermes API key.
+
+```typescript
+{
+  oracleTask: {
+    pythPushFeedId: "0xef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d",
+    pythConfigs: {
+      pushFeedShardId: 0,
+      maxStaleSeconds: 75,
+    },
+  },
+}
+```
+
+`pushFeedShardId` defaults to `0`. `maxStaleSeconds` defaults to `15` for `pythAddress` and `75` for `pythPushFeedId`. `pythConfigs.hermesUrl` can select a different Hermes endpoint for `pythAddress`. Use the nested `pythConfigs.pythAllowedConfidenceInterval` field for confidence limits; values are percentages, so `10` means 10%. The top-level `pythAllowedConfidenceInterval` field is retained only for compatibility.
+
+See [Data Feed Variable Overrides](data-feed-variable-overrides.md) for the request trust model, [Jupiter API keys](decentralized-exchanges.md#jupiter-exchange-aggregator) for its conventional placeholder behavior, and the [OracleTask reference](../task-types.md#oracletask) for every field.
 
 ## Chainlink
 

--- a/custom-feeds/build-and-deploy-feed/build-with-typescript.md
+++ b/custom-feeds/build-and-deploy-feed/build-with-typescript.md
@@ -214,12 +214,11 @@ Full task docs:
 
 ### Variable overrides (`${VAR_NAME}`)
 
-Use variable overrides to insert API keys and auth tokens into tasks at runtime.
+Use variable overrides to insert request-scoped values into task string fields at runtime. API keys and auth tokens are the safest default because they do not intentionally change feed semantics.
 
 See [Data Feed Variable Overrides](../advanced-feed-configuration/data-feed-variable-overrides.md) for the supported pattern and the full security guidance.
 
-**Critical rule:** Only use variables for **authentication** (API keys/tokens).  
-Do **not** use variables for anything that changes feed logic (URLs, JSON paths, multipliers), because consumers cannot cryptographically verify what values were injected at runtime.
+Override values are not included in the feed ID or signed checksum. Keep data sources, selections, and calculations fixed for permissionlessly updated feeds. Semantic overrides are supported when a controlled updater owns the request and consumers intentionally trust that caller.
 
 ---
 

--- a/custom-feeds/task-types.md
+++ b/custom-feeds/task-types.md
@@ -64,6 +64,13 @@ _**Example**_: HttpTask example with headers
 | `headers` | Header | A list of headers to add to this HttpTask. |
 | `body` | string | A stringified body (if any) to add to this HttpTask. |
 
+**Header fields**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `key` | string | A header key such as `Authorization` or `Content-Type` |
+| `value` | string | A value for the given header key like `Basic MYAUTHKEY` or `application/json` |
+
 ---
 
 ### SolanaAccountDataFetchTask
@@ -91,6 +98,11 @@ _**Returns**_: The value associated with the token2022 extension.
 ### SplTokenParseTask
 
 Fetch the JSON representation of an SPL token mint.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `token_account_address` | string | The publicKey of a token account to fetch the mintInfo for. |
+| `mint_address` | string | The publicKey of the token mint address. |
 
 ---
 
@@ -120,7 +132,7 @@ _**Example**_: Opens a coinbase websocket
 | `url` | string | The websocket url. |
 | `subscription` | string | The websocket message to notify of a new subscription. |
 | `max_data_age_seconds` | int32 | Minimum amount of time required between when the horses are taking out. |
-| `filter` | string | Example: "$[?(@.channel == 'ticker' && @.market == 'BTC/USD')]" |
+| `filter` | string | Incoming message JSONPath filter. Example: "$[?(@.channel == 'ticker' && @.market == 'BTC/USD')]" |
 
 ---
 
@@ -199,7 +211,7 @@ _**Example**_: Parses the price field from a JSON object
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `path` | string | https://www.npmjs.com/package/jsonpath-plus |
+| `path` | string | JSONPath formatted path to the element. https://t.ly/uLtw https://www.npmjs.com/package/jsonpath-plus |
 | `aggregation_method` | AggregationMethod | The technique that will be used to aggregate the results if walking the specified path returns multiple numerical results. |
 
 ---
@@ -246,8 +258,8 @@ _**Example**_: Extract the first JSON object from a stream
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `pattern` | string | Uses the fancy-regex Rust crate syntax. |
-| `group_number` | int32 | Defaults to 0 if not specified. |
+| `pattern` | string | The regular expression pattern to match against the input string. Uses the fancy-regex Rust crate syntax. |
+| `group_number` | int32 | The capture group number to extract (0 returns full match, 1+ returns respective capture group). Defaults to 0 if not specified. |
 
 ---
 
@@ -329,6 +341,13 @@ _**Example**_: Map HTTP response status with case-sensitive matching
 | `default_value` | string | Optional default value to return if no mapping matches. If not provided and no match is found, the task will fail. |
 | `case_sensitive` | bool | Whether the string matching should be case-sensitive. Defaults to true. |
 | `input` | string | Optional input value to map. If not provided, will use the previous task output. |
+
+**Mapping fields**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `key` | string | The string key to match against. |
+| `value` | string | The value to return if the key matches. |
 
 ---
 
@@ -424,6 +443,13 @@ _**Example**_: Returns the numerical result by multiplying by a big.
   ]
 }
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `scalar` | double | Specifies a scalar to add by. |
+| `aggregator_pubkey` | string | Specifies an aggregator to add by. |
+| `job` | OracleJob | A job whose result is computed before adding our numerical input by that result. |
+| `big` | string | A stringified big.js. `Accepts variable expansion syntax.` |
 
 ---
 
@@ -551,6 +577,13 @@ _**Example**_: Returns the numerical result by dividing by a big.
   ]
 }
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `scalar` | double | Specifies a basic scalar denominator to divide by. |
+| `aggregator_pubkey` | string | Specifies another aggregator resut to divide by. |
+| `job` | OracleJob | A job whose result is computed before dividing our numerical input by that result. |
+| `big` | string | A stringified big.js. `Accepts variable expansion syntax.` |
 
 ---
 
@@ -836,8 +869,6 @@ _**Example**_: Returns the median numerical result of 3 jobs.
 | `min_successful_required` | int32 | The minimum number of values before a successful median can be yielded. |
 | `max_range_percent` | string | The maximum range between the minimum and maximum values before a successful median can be yielded. |
 
-`max_range_percent` is a human percent string for this `MedianTask` only. It is not scaled like feed-level raw v2 `OracleFeed.maxJobRangePct`; see [Feed Parameter Units](advanced-feed-configuration/feed-parameter-units.md).
-
 ---
 
 ### MinTask
@@ -1025,6 +1056,13 @@ _**Example**_: Returns the numerical result by multiplying by a big.
 }
 ```
 
+| Field | Type | Description |
+|-------|------|-------------|
+| `scalar` | double | Specifies a scalar to multiply by. |
+| `aggregator_pubkey` | string | Specifies an aggregator to multiply by. |
+| `job` | OracleJob | A job whose result is computed before multiplying our numerical input by that result. |
+| `big` | string | A stringified big.js. `Accepts variable expansion syntax.` |
+
 ---
 
 ### PowTask
@@ -1053,6 +1091,12 @@ _**Example**_: Raise 2 to the power of 3, 2^3
   ]
 }
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `scalar` | double | Take the working value to the exponent of value. |
+| `aggregator_pubkey` | string | Take the working value to the exponent of the aggregators value. |
+| `big` | string | A stringified big.js. `Accepts variable expansion syntax.` |
 
 ---
 
@@ -1173,6 +1217,13 @@ _**Example**_: Returns the numerical result by multiplying by a big.
 }
 ```
 
+| Field | Type | Description |
+|-------|------|-------------|
+| `scalar` | double | Specifies a scalar to subtract by. |
+| `aggregator_pubkey` | string | Specifies an aggregator to subtract by. |
+| `job` | OracleJob | A job whose result is computed before subtracting our numerical input by that result. |
+| `big` | string | A stringified big.js. `Accepts variable expansion syntax.` |
+
 ---
 
 ## DeFi & DEX
@@ -1262,12 +1313,48 @@ _**Example**_: Fetch the JupiterSwap price for exchanging 1000 SOL into USDC.
 }
 ```
 
+_**Example**_: Supply a request-scoped Jupiter API key without storing it in the job.
+
+```json
+{
+  "jupiterSwapTask": {
+    "inTokenAddress": "So11111111111111111111111111111111111111112",
+    "outTokenAddress": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    "baseAmountString": "1",
+    "apiKey": "${JUPITER_API_KEY}"
+  }
+}
+```
+
+Pass the matching non-empty value when requesting the feed:
+
+```typescript
+const response = await gateway.fetchSignaturesConsensus({
+  // ...
+  variableOverrides: {
+    JUPITER_API_KEY: process.env.JUPITER_API_KEY!,
+  },
+});
+```
+
 | Field | Type | Description |
 |-------|------|-------------|
 | `in_token_address` | string | The input token address. |
 | `out_token_address` | string | The output token address. |
+| `allow_list` | FilterList | A list of AMM markets to allow. |
+| `deny_list` | FilterList | A list of AMM markets to deny. |
+| `base_amount` | double | The amount of `in_token_address` tokens to swap. |
+| `quote_amount` | double | The amount of `out_token_address` tokens to swap. |
+| `base_amount_string` | string | The amount of `in_token_address` tokens to swap. |
+| `quote_amount_string` | string | The amount of `out_token_address` tokens to swap. |
 | `slippage` | double | The allowable slippage on the swap in decimal form (e.g. 0.5 is 0.5% slippage) |
-| `api_key` | string | Optional API key for authenticated requests |
+| `api_key` | string | Optional Jupiter API key. For a request-scoped key, set this field to a variable placeholder such as `${JUPITER_API_KEY}` and provide the matching non-empty value through `variableOverrides` when requesting the feed. An override is only applied when this field contains a matching placeholder. If the placeholder is unresolved, the task fails before contacting Jupiter. If this field is omitted or empty, the oracle's configured Jupiter key is used when available. Do not hardcode credentials in an oracle job. |
+
+**FilterList fields**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `labels` | string | A list of Jupiter AMM labels to allow or deny (e.g. 'Raydium', 'Orca') |
 
 ---
 
@@ -1355,6 +1442,13 @@ _**Example**_: Fetch the exchange rate from the Raydium SOL/USDC pool
 |-------|------|-------------|
 | `in_token_address` | string | Used alongside mercurial_pool_address to specify the input token for a swap. |
 | `out_token_address` | string | Used alongside mercurial_pool_address to specify the output token for a swap. |
+| `mercurial_pool_address` | string | Mercurial finance pool address. A full list can be found here: https://github.com/mercurial-finance/stable-swap-n-pool-js |
+| `saber_pool_address` | string | Saber pool address. A full list can be found here: https://github.com/saber-hq/saber-registry-dist |
+| `orca_pool_token_mint_address` | string | **@deprecated** Use orcaPoolAddress |
+| `raydium_pool_address` | string | The Raydium liquidity pool ammId. A full list can be found here: https://raydium.io/pools |
+| `orca_pool_address` | string | Pool address for an Orca LP pool or whirlpool. A full list of Orca LP pools can be found here: https://www.orca.so/pools |
+| `port_reserve_address` | string | The Port reserve pubkey. A full list can be found here: https://api-v1.port.finance/reserves |
+| `defituna_pool_address` | string | DefiTuna Fusion AMM pool address. Program ID: tuna4uSQZncNeeiAMKbstuxA9CUkHH6HmC64wgmnogD |
 
 ---
 
@@ -1363,7 +1457,8 @@ _**Example**_: Fetch the exchange rate from the Raydium SOL/USDC pool
 Fetch LP token price info from a number of supported exchanges.
 
 See our blog post on [Fair LP Token Oracles](/blog/2022/01/20/Fair-LP-Token-Oracles)
-*NOTE**: This is not the swap price but the price of the underlying LP token.
+
+**NOTE**: This is not the swap price but the price of the underlying LP token.
 
 _**Input**_: None
 
@@ -1411,6 +1506,10 @@ _**Example**_: Fetch the fair price Raydium LP token price of the SOL/USDC pool
 
 | Field | Type | Description |
 |-------|------|-------------|
+| `mercurial_pool_address` | string | Mercurial finance pool address. A full list can be found here: https://github.com/mercurial-finance/stable-swap-n-pool-js |
+| `saber_pool_address` | string | Saber pool address. A full list can be found here: https://github.com/saber-hq/saber-registry-dist |
+| `orca_pool_address` | string | Orca pool address. A full list can be found here: https://www.orca.so/pools |
+| `raydium_pool_address` | string | The Raydium liquidity pool ammId. A full list can be found here: https://raydium.io/pools |
 | `price_feed_addresses` | string | A list of Switchboard aggregator accounts used to calculate the fair LP price. This ensures the price is based on the previous round to mitigate flash loan price manipulation. |
 | `price_feed_jobs` | OracleJob | A list of OracleJobs to execute in order to yield the price feed jobs to use for the fair price formula. |
 | `use_fair_price` | bool | If enabled and price_feed_addresses provided, the oracle will calculate the fair LP price based on the liquidity pool reserves. See our blog post for more information: https://switchboardxyz.medium.com/fair-lp-token-oracles-94a457c50239 |
@@ -1455,11 +1554,11 @@ _**Example**_: Fetch a quote with custom slippage and gas price.
 | Field | Type | Description |
 |-------|------|-------------|
 | `from_address` | string | The Ethereum address of the user making the swap (default: zero address). |
-| `token_in` | string | Examples: "native", "0x760AfE86e5de5fa0Ee542fc7B7B713e1c5425701" |
+| `token_in` | string | The input token identifier (EVM address, "native", or ERC1155 format). Examples: "native", "0x760AfE86e5de5fa0Ee542fc7B7B713e1c5425701" |
 | `token_out` | string | The output token identifier (EVM address, "native", or ERC1155 format). |
 | `amount` | string | The amount to swap in wei (e.g., "1000000000000000000" for 1 token with 18 decimals). |
 | `slippage_tolerance_bps` | uint32 | Slippage tolerance in basis points (1-10000, e.g., 100 = 1%). Default: 10000 (100%). |
-| `gas_price_wei` | string | Default: "1000000000" (1 Gwei). |
+| `gas_price_wei` | string | Gas price to simulate with in wei. Influences route selection - higher values weight gas usage more. Default: "1000000000" (1 Gwei). |
 | `max_routes` | uint32 | Maximum number of routes to return (default: 1). Routes range from most valuable to most stable. |
 | `input_decimals` | uint32 | Number of decimals for the input token (default: 18). |
 | `output_decimals` | uint32 | Number of decimals for the output token (default: 18). |
@@ -1547,9 +1646,9 @@ Execute a swap task in the Pump AMM based on the given parameters.
 | Field | Type | Description |
 |-------|------|-------------|
 | `pool_address` | string | Required. The address of the liquidity pool in the Pump AMM. |
-| `in_amount` | double | - Default value: `1` (Swap 1 full token). |
-| `max_slippage` | double | - Default value: `3` (3% slippage tolerance). |
-| `is_x_for_y` | bool | - Default value: `true`. |
+| `in_amount` | double | Optional. The input token amount for the swap. - This value should in full units of the input token. - Default value: `1` (Swap 1 full token). |
+| `max_slippage` | double | Optional. The maximum allowed slippage for the swap, expressed as a percentage. - Example: `0.5` represents 0.5% slippage tolerance. - Default value: `3` (3% slippage tolerance). |
+| `is_x_for_y` | bool | Optional. Indicates the swap direction: - `true`: Swapping token X for token Y. - `false`: Swapping token Y for token X. - Default value: `true`. |
 
 ---
 
@@ -1585,18 +1684,13 @@ _**Input**_: None
 
 _**Returns**_: The swap price on Titan for a given input and output token mint address.
 
-_**Important**_: Set `userPublicKey` / `user_public_key` to a valid Solana wallet public key.
-If this is missing or invalid, Titan routing can return no routes and the task can fail.
-`amount` is specified in whole token units (for example, `"1"` for 1 USDC), then converted internally to raw atoms using mint decimals before calling Titan.
-
 _**Example**_: Fetch the Titan price for exchanging 1 SOL into USDC.
 
 ```json
 {
   "titanTask": {
     "inTokenAddress": "So11111111111111111111111111111111111111112",
-    "outTokenAddress": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-    "userPublicKey": "7M6M9Ybbp6kAMPxQqvYXvyfZ87Z84qxdjQ671Vkj2rWQ"
+    "outTokenAddress": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
   }
 }
 ```
@@ -1618,8 +1712,8 @@ _**Example**_: Fetch the Titan price for exchanging 1000 SOL into USDC with slip
 |-------|------|-------------|
 | `in_token_address` | string | The input token mint address (base58 encoded). |
 | `out_token_address` | string | The output token mint address (base58 encoded). |
-| `amount` | string | The amount of input token units to swap (human-readable units, not raw atoms). If omitted, defaults to `1` token unit. |
-| `user_public_key` | string | User wallet public key used for quote/route context (base58 encoded). Required in practice for reliable routing; missing/invalid values can cause quote failures. |
+| `amount` | string | The amount of tokens to swap (raw atoms, not scaled by decimals). |
+| `user_public_key` | string | Optional user public key for transaction generation (base58 encoded). |
 | `swap_mode` | SwapMode | Whether the amount is in terms of input or output token. Defaults to ExactIn. |
 | `slippage_bps` | uint32 | Allowed slippage in basis points (e.g., 50 = 0.5%). |
 | `dexes` | FilterList | If set, constrain quotes to the given set of DEXes. |
@@ -1628,6 +1722,12 @@ _**Example**_: Fetch the Titan price for exchanging 1000 SOL into USDC with slip
 | `providers` | string | If set, limit quotes to the given set of provider IDs. |
 | `access_token` | string | Optional API access token for authenticated requests |
 | `api_endpoint` | string | Optional API endpoint override (defaults to partners.api.titan.exchange) |
+
+**FilterList fields**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `labels` | string | A list of DEX labels to allow or deny (e.g., 'Raydium', 'Orca') |
 
 ---
 
@@ -1672,7 +1772,7 @@ _**Example**_: Compute the median APY for an LST over the last 100 epochs
 |-------|------|-------------|
 | `lst_mint` | string | Required. The LST mint address for which historical yield data is queried. |
 | `operation` | Operation | Required. The statistical operation to apply to the historical yield dataset. |
-| `epochs` | int32 | - If `epochs > 0`, only the last `epochs` entries will be included. |
+| `epochs` | int32 | Optional. The number of epochs to sample for the computation. - If `epochs = 0`, all available historical data will be used. - If `epochs > 0`, only the last `epochs` entries will be included. |
 
 ---
 
@@ -1700,7 +1800,7 @@ Grab the price of an Sanctum LST relative to SOL.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `lst_mint` | string | e.g. INF - 5oVNBeEEQvYi1cX3ir8Dx5n1P7pdxydbGF2X4TxVusJm |
+| `lst_mint` | string | The address of the LST mint. e.g. INF - 5oVNBeEEQvYi1cX3ir8Dx5n1P7pdxydbGF2X4TxVusJm |
 | `skip_epoch_check` | bool | Allow the check to see if the LST was cranked for the current epoch to be skipped. |
 
 ---
@@ -1781,9 +1881,9 @@ _**Example**_: vSUI (2 shared objects - StakePool + Metadata):
 | `package_id` | string | The package ID containing the exchange rate function. |
 | `module` | string | The module name containing the exchange rate function. |
 | `function` | string | The function name to call (e.g., "get_sui_by_stsui", "from_shares", "get_exchange_rate"). |
-| `shared_objects` | string | These will be resolved to SharedObject arguments with their initial_shared_version. |
-| `provide_lst_amount` | bool | Set to false for functions like "get_exchange_rate(staking)" that return the rate directly. |
-| `rpc_url` | string | If not specified, uses the default mainnet RPC. |
+| `shared_objects` | string | List of shared object IDs to pass as arguments (in order). These will be resolved to SharedObject arguments with their initial_shared_version. |
+| `provide_lst_amount` | bool | If true, appends the LST amount (1e9 = 1 token) as a Pure u64 argument after shared objects. Set to true for functions like "get_sui_by_stsui(staking, amount)" or "from_shares(pool, meta, amount)". Set to false for functions like "get_exchange_rate(staking)" that return the rate directly. |
+| `rpc_url` | string | The Sui RPC endpoint to use for fetching on-chain data. If not specified, uses the default mainnet RPC. |
 
 ---
 
@@ -1795,7 +1895,7 @@ No inputs required - uses hardcoded vSUI pool addresses.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `rpc_url` | string | If not specified, uses the default mainnet RPC. |
+| `rpc_url` | string | The Sui RPC endpoint to use for fetching on-chain data. If not specified, uses the default mainnet RPC. |
 
 ---
 
@@ -1857,6 +1957,35 @@ _**Example**_: The Pyth SOL/USD oracle price.
 }
 ```
 
+_**Example**_: The Pyth SOL/USD oracle price using a Hermes API key supplied at execution time.
+
+```json
+{
+  "oracleTask": {
+    "pythAddress": "H6ARHf6YXhGYeQfUzQNGk6rDNnLBQKrenN712K4AQJEG",
+    "pythConfigs": {
+      "apiKey": "${PYTH_API_KEY}"
+    }
+  }
+}
+```
+
+Supply the key in the execution request as `"variableOverrides": { "PYTH_API_KEY": "..." }`.
+
+_**Example**_: The Pyth SOL/USD push oracle price.
+
+```json
+{
+  "oracleTask": {
+    "pythPushFeedId": "0xef0d8b6fda2ceba41da15d4095d1da392a0d2f8ed0c6c7bc0f4cfac8c280b56d",
+    "pythConfigs": {
+      "pushFeedShardId": 0,
+      "maxStaleSeconds": 75
+    }
+  }
+}
+```
+
 _**Example**_: The Chainlink SOL/USD oracle price.
 
 ```json
@@ -1869,7 +1998,22 @@ _**Example**_: The Chainlink SOL/USD oracle price.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `pyth_allowed_confidence_interval` | double | represent 10%, enter the value as 10, not 0.1. |
+| `switchboard_address` | string | Mainnet address of a Switchboard feed. Switchboard is decentralized and allows anyone to build their own feed. |
+| `pyth_address` | string | Mainnet address for a Pyth feed. A full list can be found here: https://pyth.network/price-feeds/ |
+| `chainlink_address` | string | Mainnet address for a Chainlink feed. A full list can be found here: https://docs.chain.link/docs/solana/data-feeds-solana |
+| `pyth_push_feed_id` | string | Pyth price feed ID for an upgraded Solana push feed. The task derives and reads the on-chain feed account using this ID and pyth_configs.push_feed_shard_id; it does not use Hermes or a Hermes API key. |
+| `pyth_allowed_confidence_interval` | double | Value (as a percentage) that the lower bound confidence interval is of the actual value. Confidence intervals that are larger that this treshold are rejected. The confidence interval should be provided as a raw percentage value. For example, to represent 10%, enter the value as 10, not 0.1. |
+| `pyth_configs` | PythConfigs | Optional settings for Pyth Hermes and on-chain push-feed tasks. |
+
+**PythConfigs fields**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `hermes_url` | string | Optional Hermes base URL used by pyth_address tasks. |
+| `pyth_allowed_confidence_interval` | double | Preferred Pyth confidence interval setting, expressed as a raw percentage. For example, use 10 to represent 10%, not 0.1. |
+| `max_stale_seconds` | int32 | Maximum accepted price age in seconds. Defaults to 15 seconds for pyth_address and 75 seconds for pyth_push_feed_id. |
+| `push_feed_shard_id` | uint32 | Pyth push-feed shard used only by pyth_push_feed_id. Defaults to shard 0. |
+| `api_key` | string | Optional API key for authenticated Pyth Hermes requests made by pyth_address tasks. Use a variable placeholder such as `${PYTH_API_KEY}` and supply a matching non-empty variableOverrides value at execution time; do not hardcode credentials. This field takes precedence when it is non-empty. If it is omitted or empty, variableOverrides.PYTH_API_KEY is accepted as a compatibility fallback. That fallback is request-wide: the same value is used by every pyth_address task in the execution that does not configure its own api_key. Pyth push-feed tasks read on-chain accounts and do not use this API key. |
 
 ---
 
@@ -2092,6 +2236,13 @@ specified strategy.
 
 Fetch the current price of a perpetual market.
 
+| Field | Type | Description |
+|-------|------|-------------|
+| `mango_market_address` | string | Market address for a mango perpetual market. A full list can be found here: https://github.com/blockworks-foundation/mango-client-v3/blob/main/src/ids.json |
+| `drift_market_address` | string | Market address for a drift perpetual market. A full list can be found here: https://github.com/drift-labs/protocol-v1/blob/master/sdk/src/constants/markets.ts |
+| `zeta_market_address` | string | Market address for a zeta perpetual market. |
+| `zo_market_address` | string | Market address for a 01 protocol perpetual market. |
+
 ---
 
 ### TurboEthRedemptionRateTask
@@ -2122,17 +2273,20 @@ _**Returns**_: A positive Decimal number with 18 decimal places (scale 18)
 **Hash-to-Decimal Conversion Algorithm**
 
 **Step-by-Step Process**
+
 **1. Compute BLAKE2b-128 hash** (produces 16 bytes / 128 bits)
    ```
    Input:  "Hello, World!"
    Output: 3895c59e4aeb0903396b5be3fbec69fe
    ```
+
 **2. Truncate to 96 bits (12 bytes)** - keep the **most significant** bits
    ```
    KEPT (first 12 bytes):      3895c59e4aeb0903396b5be3
    DISCARDED (last 4 bytes):   fbec69fe
    ```
    This follows cryptographic standards where truncation keeps the leftmost/most significant bits.
+
 **3. Pad to 16 bytes** for u128 representation
    ```
    Add 4 zero bytes at the BEGINNING:
@@ -2142,12 +2296,14 @@ _**Returns**_: A positive Decimal number with 18 decimal places (scale 18)
    padding      first 12 bytes
    (4 bytes)    (most significant)
    ```
+
 **4. Interpret as u128 using big-endian** byte order
    ```
    Hex:     0x000000003895c59e4aeb0903396b5be3
    Decimal: 17512223723299011049621773283
    ```
    Big-endian is the standard for cryptographic hash representations.
+
 **5. Convert to Decimal** with scale 18 (18 decimal places)
    ```
    Value:  17512223723299011049621773283
@@ -2323,6 +2479,13 @@ _**Example**_: CacheTask storing ${ONE} = 1
 |-------|------|-------------|
 | `cache_items` | CacheItem | A list of cached variables to reference in the job with `${VARIABLE_NAME}`. |
 
+**CacheItem fields**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `variable_name` | string | The name of the variable to store in cache to reference later with `${VARIABLE_NAME}`. |
+| `job` | OracleJob | The OracleJob to execute to yield the value to store in cache. |
+
 ---
 
 ### ComparisonTask
@@ -2350,6 +2513,10 @@ _**Example**_: Return 1 if lhs > rhs else 0
 | Field | Type | Description |
 |-------|------|-------------|
 | `op` | Operation | The type of operator to use on the left (lhs) and right (rhs) operand. |
+| `lhs` | OracleJob | OracleJob where the executed result is equal to the left hand side operand. |
+| `lhs_value` | string | String or `${CACHE_KEY}` representing the left hand side operand. |
+| `rhs` | OracleJob | OracleJob where the executed result is equal to the right hand side operand. |
+| `rhs_value` | string | String or `${CACHE_KEY}` representing the right hand side operand. |
 | `on_true` | OracleJob | The OracleJob to execute if the condition evaluates to true. |
 | `on_true_value` | string | The result to use if the condition evaluates to true. Can be set to a `${CACHE_KEY}`. |
 | `on_false` | OracleJob | The OracleJob to execute if the condition evaluates to false. |
@@ -2398,7 +2565,7 @@ _**Example**_: Returns the numerical result from the conditionalTask's subtasks,
 | Field | Type | Description |
 |-------|------|-------------|
 | `attempt` | Task | A list of subtasks to process in an attempt to produce a valid numerical result. |
-| `on_failure` | Task | result. |
+| `on_failure` | Task | A list of subtasks that will be run if `attempt` subtasks are unable to produce an acceptable result. |
 
 ---
 
@@ -2409,8 +2576,6 @@ Deprecated compatibility task for the legacy Switchboard secrets-server flow.
 `SecretsTask` is no longer officially supported. The hosted secrets service has been taken down, and new integrations should use `variableOverrides` to inject API keys and other authentication credentials at request time.
 
 See the Data Feed Variable Overrides guide for the supported pattern.
-
-Use this when your job needs credentials such as API keys, auth headers, or other sensitive values that should not live directly in the feed definition.
 
 _**Input**_: None
 
@@ -2430,29 +2595,6 @@ _**Example**_: Legacy `SecretsTask`
 |-------|------|-------------|
 | `authority` | string | The authority of the secrets that are to be requested. |
 | `url` | string | Legacy server URL override for historical or self-hosted deployments. The old hosted default at https://api.secrets.switchboard.xyz is no longer available. |
-
-**How it fits into a feed**
-
-`SecretsTask` is typically placed near the top of a job. The returned secrets are then referenced later via variable expansion such as `${API_KEY}` in downstream tasks.
-
-Typical flow:
-
-1. Create a user profile for the wallet that owns the secrets.
-2. Add one or more named secrets to that profile.
-3. Add `SecretsTask` to the job with the secret authority.
-4. Reference the secret values in later tasks using `${SECRET_NAME}`.
-5. Whitelist the relevant measurement / MrEnclave values that should be allowed to access that secret.
-
-**Hosted vs self-hosted**
-
-- Hosted app: [https://secrets.switchboard.xyz/connect](https://secrets.switchboard.xyz/connect)
-- Self-hosted server: [https://github.com/switchboard-xyz/sbv3/tree/main/apps/secrets-server](https://github.com/switchboard-xyz/sbv3/tree/main/apps/secrets-server)
-
-**Related resources**
-
-- [Build with TypeScript](build-and-deploy-feed/build-with-typescript.md#secretstask)
-- [Data Feed Variable Overrides](advanced-feed-configuration/data-feed-variable-overrides.md)
-- [Secrets example repository](https://github.com/switchboard-xyz/sb-on-demand-examples/tree/main/sb-on-demand-secret/sb-on-demand-secrets)
 
 ---
 
@@ -2509,6 +2651,13 @@ _**Example**_: Returns the value stored in a CacheTask variable
   }
 }
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `value` | double | The value that will be returned from this task. |
+| `aggregator_pubkey` | string | Specifies an aggregatorr to pull the value of. |
+| `big` | string | A stringified big.js. `Accepts variable expansion syntax.` |
+| `hex` | string | A stringified hex number (0x prefix is optional). |
 
 ---
 
@@ -2693,6 +2842,11 @@ _**Example**_: Read from an existing STEP/USD aggregator
   }
 }
 ```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `step_job` | MedianTask | median task containing the job definitions to fetch the STEP/USD price |
+| `step_aggregator_pubkey` | string | existing aggregator pubkey for STEP/USD |
 
 ---
 

--- a/scripts/generate-task-docs.js
+++ b/scripts/generate-task-docs.js
@@ -57,13 +57,11 @@ const CATEGORIES = {
 };
 
 async function fetchProto() {
-  // Try local file first
   if (fs.existsSync(LOCAL_PROTO_PATH)) {
     console.log(`Using local proto file: ${LOCAL_PROTO_PATH}`);
     return fs.readFileSync(LOCAL_PROTO_PATH, 'utf-8');
   }
 
-  // Fall back to GitHub
   console.log(`Fetching from GitHub: ${PROTO_URL}`);
   const response = await fetch(PROTO_URL);
   if (!response.ok) {
@@ -72,139 +70,191 @@ async function fetchProto() {
   return response.text();
 }
 
+function countBraces(line) {
+  let count = 0;
+  for (const char of line) {
+    if (char === '{') count++;
+    if (char === '}') count--;
+  }
+  return count;
+}
+
+function findBlockEnd(lines, startIndex) {
+  let depth = 0;
+  let started = false;
+
+  for (let i = startIndex; i < lines.length; i++) {
+    if (lines[i].includes('{')) started = true;
+    const delta = countBraces(lines[i]);
+    depth += delta;
+
+    if (started && depth === 0) return i;
+  }
+
+  throw new Error(`Unclosed proto block starting on line ${startIndex + 1}`);
+}
+
+function collectFieldDescription(lines, fieldIndex) {
+  const comments = [];
+  let i = fieldIndex - 1;
+
+  while (i >= 0 && lines[i].trim().startsWith('///')) {
+    comments.unshift(lines[i].trim().replace(/^\/\/\/\s?/, ''));
+    i--;
+  }
+
+  if (comments.length > 0) {
+    return collapseTableProse(comments.join('\n'));
+  }
+
+  const inlineComment = lines[fieldIndex].match(/\/\/\s*(.+)$/);
+  return inlineComment ? collapseTableProse(inlineComment[1]) : '';
+}
+
+function collapseTableProse(text) {
+  return text
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function parseField(lines, fieldIndex) {
+  const fieldMatch = lines[fieldIndex].match(
+    /^\s*(?:optional|repeated|required)?\s*([.\w]+)\s+(\w+)\s*=\s*\d+/
+  );
+  if (!fieldMatch) return null;
+
+  return {
+    type: fieldMatch[1],
+    name: fieldMatch[2],
+    description: collectFieldDescription(lines, fieldIndex)
+  };
+}
+
+function extractFieldsFromRange(lines, startIndex, endIndex) {
+  const fields = [];
+
+  for (let i = startIndex; i < endIndex; i++) {
+    const declaration = lines[i].match(/^\s*(message|enum|oneof)\s+\w+\s*\{/);
+    if (declaration) {
+      const blockEnd = findBlockEnd(lines, i);
+      if (declaration[1] === 'oneof') {
+        fields.push(...extractFieldsFromRange(lines, i + 1, blockEnd));
+      }
+      i = blockEnd;
+      continue;
+    }
+
+    const field = parseField(lines, i);
+    if (field) fields.push(field);
+  }
+
+  return fields;
+}
+
+function parseMessageDefinition(lines, messageStartIndex) {
+  const messageMatch = lines[messageStartIndex].match(/^\s*message\s+(\w+)\s*\{/);
+  if (!messageMatch) {
+    throw new Error(`Expected message declaration on line ${messageStartIndex + 1}`);
+  }
+
+  const endIndex = findBlockEnd(lines, messageStartIndex);
+  const fields = [];
+  const nestedMessages = new Map();
+
+  for (let i = messageStartIndex + 1; i < endIndex; i++) {
+    const declaration = lines[i].match(/^\s*(message|enum|oneof)\s+(\w+)\s*\{/);
+    if (declaration) {
+      const blockEnd = findBlockEnd(lines, i);
+      if (declaration[1] === 'message') {
+        nestedMessages.set(declaration[2], {
+          fields: extractFieldsFromRange(lines, i + 1, blockEnd)
+        });
+      } else if (declaration[1] === 'oneof') {
+        fields.push(...extractFieldsFromRange(lines, i + 1, blockEnd));
+      }
+      i = blockEnd;
+      continue;
+    }
+
+    const field = parseField(lines, i);
+    if (field) fields.push(field);
+  }
+
+  const referencedTypes = new Set(fields.map(field => field.type));
+  const referencedNestedMessages = new Map(
+    [...nestedMessages].filter(([name]) => referencedTypes.has(name))
+  );
+
+  return {
+    name: messageMatch[1],
+    endIndex,
+    fields,
+    nestedMessages: referencedNestedMessages
+  };
+}
+
+function extractTaskDocumentation(lines, messageStartIndex) {
+  let i = messageStartIndex - 1;
+  while (i >= 0 && lines[i].trim() === '') i--;
+
+  if (i >= 0 && lines[i].trim().endsWith('*/')) {
+    const commentEnd = i;
+    while (i >= 0 && !lines[i].includes('/*')) i--;
+    if (i >= 0) {
+      const commentText = lines.slice(i, commentEnd + 1).join('\n');
+      const match = commentText.match(/\/\*\s*([\s\S]*?)\s*\*\//);
+      return match ? cleanDocumentation(match[1]) : null;
+    }
+  }
+
+  if (i >= 0 && lines[i].trim().startsWith('///')) {
+    const comments = [];
+    while (i >= 0 && lines[i].trim().startsWith('///')) {
+      comments.unshift(lines[i].trim().replace(/^\/\/\/\s?/, ''));
+      i--;
+    }
+    return comments.join('\n');
+  }
+
+  return null;
+}
+
 function parseTaskDocumentation(protoContent) {
   const tasks = new Map();
   const lines = protoContent.split('\n');
 
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const messageMatch = line.match(/^\s*message\s+(\w+Task)\s*\{/);
+    const messageMatch = lines[i].match(/^\s*message\s+(\w+Task)\s*\{/);
+    if (!messageMatch) continue;
 
-    if (messageMatch) {
-      const taskName = messageMatch[1];
-      let doc = null;
-
-      // Look backwards for documentation immediately before this message
-      let j = i - 1;
-
-      // Skip empty lines
-      while (j >= 0 && lines[j].trim() === '') j--;
-
-      // Check for block comment (ends with */)
-      if (j >= 0 && lines[j].trim().endsWith('*/')) {
-        let commentEnd = j;
-        // Search backwards for the matching /*
-        while (j >= 0 && !lines[j].includes('/*')) {
-          j--;
-        }
-        if (j >= 0) {
-          // Extract just this comment block
-          const commentLines = lines.slice(j, commentEnd + 1);
-          const commentText = commentLines.join('\n');
-          const match = commentText.match(/\/\*\s*([\s\S]*?)\s*\*\//);
-          if (match) {
-            doc = cleanDocumentation(match[1]);
-          }
-        }
-      }
-      // Check for /// comments immediately before (existing logic)
-      else if (j >= 0 && lines[j].trim().startsWith('///')) {
-        const tripleSlashComments = [];
-        while (j >= 0 && lines[j].trim().startsWith('///')) {
-          tripleSlashComments.unshift(lines[j].trim().replace(/^\/\/\/\s?/, ''));
-          j--;
-        }
-        doc = tripleSlashComments.join('\n');
-      }
-
-      // Extract fields from the message body
-      const fields = extractFields(lines, i);
-
-      tasks.set(taskName, { doc, fields });
-    }
+    const message = parseMessageDefinition(lines, i);
+    tasks.set(message.name, {
+      doc: extractTaskDocumentation(lines, i),
+      fields: message.fields,
+      nestedMessages: message.nestedMessages
+    });
+    i = message.endIndex;
   }
 
   return tasks;
 }
 
 function extractFields(lines, messageStartIndex) {
-  const fields = [];
-  let braceCount = 0;
-  let insideMessage = false;
-  let nestedDepth = 0;
-
-  for (let i = messageStartIndex; i < lines.length; i++) {
-    const line = lines[i];
-
-    // Count braces
-    for (const char of line) {
-      if (char === '{') {
-        braceCount++;
-        if (!insideMessage) {
-          insideMessage = true;
-        } else {
-          nestedDepth++;
-        }
-      } else if (char === '}') {
-        braceCount--;
-        if (nestedDepth > 0) {
-          nestedDepth--;
-        }
-      }
-    }
-
-    // Exit when we close the main message
-    if (insideMessage && braceCount === 0) break;
-
-    // Skip if we're inside a nested message/enum/oneof
-    if (nestedDepth > 0) continue;
-
-    // Skip nested message/enum/oneof declarations (they open a new brace level)
-    if (line.match(/^\s*(message|enum|oneof)\s+\w+/)) {
-      continue;
-    }
-
-    // Match field definitions: optional/repeated type name = number;
-    const fieldMatch = line.match(/^\s*(optional|repeated|required)?\s*(\w+)\s+(\w+)\s*=\s*\d+/);
-    if (fieldMatch && insideMessage) {
-      const [, , type, name] = fieldMatch;
-
-      // Look for /// comment on the line before
-      let description = '';
-      const prevLine = lines[i - 1] || '';
-      if (prevLine.trim().startsWith('///')) {
-        description = prevLine.trim().replace(/^\/\/\/\s?/, '');
-      }
-      // Also check for inline comment
-      const inlineCommentMatch = line.match(/\/\/\s*(.+)$/);
-      if (inlineCommentMatch && !description) {
-        description = inlineCommentMatch[1];
-      }
-
-      fields.push({
-        name: name,
-        type: type,
-        description: description
-      });
-    }
-  }
-
-  return fields;
+  return parseMessageDefinition(lines, messageStartIndex).fields;
 }
 
 function cleanDocumentation(doc) {
   if (!doc) return null;
 
-  // Clean up the documentation
   let cleaned = doc
-    // Remove the block-comment prefix from lines like " * text" without
-    // stripping intentional markdown such as "**bold**".
     .replace(/^\s*\*(?!\*)\s?/gm, '')
-    // Normalize whitespace
     .replace(/\r\n/g, '\n')
     .trim();
 
-  // Format JSON code blocks for better readability
   cleaned = formatJsonCodeBlocks(cleaned);
   cleaned = demoteInternalHeadings(cleaned);
 
@@ -212,7 +262,6 @@ function cleanDocumentation(doc) {
 }
 
 function formatJsonCodeBlocks(text) {
-  // Match ```json ... ``` code blocks
   return text.replace(/```json\s*([\s\S]*?)```/g, (match, jsonContent) => {
     const trimmed = jsonContent.trim();
     try {
@@ -220,16 +269,12 @@ function formatJsonCodeBlocks(text) {
       const formatted = JSON.stringify(parsed, null, 2);
       return '```json\n' + formatted + '\n```';
     } catch {
-      // If parsing fails, return original
       return match;
     }
   });
 }
 
 function demoteInternalHeadings(text) {
-  // Task pages already provide the primary heading structure. Converting nested
-  // headings inside proto comments to bold labels keeps GitBook's page nav from
-  // treating them as top-level sections.
   return text.replace(/^(#{2,6})\s+(.+)$/gm, (_, __, headingText) => {
     return `**${headingText.trim()}**`;
   });
@@ -237,26 +282,33 @@ function demoteInternalHeadings(text) {
 
 function categorizeTask(taskName) {
   for (const [category, tasks] of Object.entries(CATEGORIES)) {
-    if (tasks.includes(taskName)) {
-      return category;
-    }
+    if (tasks.includes(taskName)) return category;
   }
   return 'Other';
+}
+
+function renderFieldTable(fields) {
+  const documentedFields = fields.filter(field => field.description);
+  if (documentedFields.length === 0) return '';
+
+  let markdown = '| Field | Type | Description |\n';
+  markdown += '|-------|------|-------------|\n';
+  for (const field of documentedFields) {
+    const description = collapseTableProse(field.description).replace(/\|/g, '\\|');
+    markdown += `| \`${field.name}\` | ${field.type} | ${description} |\n`;
+  }
+  return `${markdown}\n`;
 }
 
 function generateMarkdown(tasks) {
   const categorized = {};
 
-  // Categorize all tasks
   for (const [taskName, taskData] of tasks) {
     const category = categorizeTask(taskName);
-    if (!categorized[category]) {
-      categorized[category] = [];
-    }
+    if (!categorized[category]) categorized[category] = [];
     categorized[category].push({ name: taskName, ...taskData });
   }
 
-  // Generate markdown
   let markdown = `# Task Types
 
 > This documentation is automatically generated from the [job_schemas.proto](https://github.com/switchboard-xyz/sbv3/blob/main/protos/job_schemas.proto) source file.
@@ -267,7 +319,6 @@ Some tasks do not consume the running input (such as HttpTask and WebsocketTask)
 
 `;
 
-  // Define category order
   const categoryOrder = [
     'Data Fetching',
     'Parsing',
@@ -286,34 +337,21 @@ Some tasks do not consume the running input (such as HttpTask and WebsocketTask)
     if (!tasksInCategory || tasksInCategory.length === 0) continue;
 
     markdown += `## ${category}\n\n`;
-
-    // Sort tasks alphabetically within category
     tasksInCategory.sort((a, b) => a.name.localeCompare(b.name));
 
-    for (const { name, doc, fields } of tasksInCategory) {
+    for (const { name, doc, fields, nestedMessages } of tasksInCategory) {
       markdown += `### ${name}\n\n`;
+      markdown += doc ? `${doc}\n\n` : '*No description available.*\n\n';
+      markdown += renderFieldTable(fields || []);
 
-      if (doc) {
-        markdown += `${doc}\n\n`;
-      } else {
-        markdown += `*No description available.*\n\n`;
-      }
-
-      // Add field table if there are documented fields
-      if (fields && fields.length > 0) {
-        const documentedFields = fields.filter(f => f.description);
-        if (documentedFields.length > 0) {
-          markdown += `| Field | Type | Description |\n`;
-          markdown += `|-------|------|-------------|\n`;
-          for (const field of documentedFields) {
-            const escapedDesc = field.description.replace(/\|/g, '\\|');
-            markdown += `| \`${field.name}\` | ${field.type} | ${escapedDesc} |\n`;
-          }
-          markdown += `\n`;
+      if (nestedMessages) {
+        for (const [nestedName, nestedMessage] of nestedMessages) {
+          const table = renderFieldTable(nestedMessage.fields || []);
+          if (table) markdown += `**${nestedName} fields**\n\n${table}`;
         }
       }
 
-      markdown += `---\n\n`;
+      markdown += '---\n\n';
     }
   }
 
@@ -344,4 +382,19 @@ async function main() {
   console.log('Done!');
 }
 
-main().catch(console.error);
+module.exports = {
+  collapseTableProse,
+  extractFields,
+  fetchProto,
+  generateMarkdown,
+  main,
+  parseTaskDocumentation,
+  renderFieldTable
+};
+
+if (require.main === module) {
+  main().catch(error => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/generate-task-docs.test.js
+++ b/scripts/generate-task-docs.test.js
@@ -1,0 +1,128 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  generateMarkdown,
+  parseTaskDocumentation
+} = require('./generate-task-docs');
+
+const PROTO_FIXTURE = [
+  'message OracleJob {',
+  '  /* Jupiter docs. */',
+  '  message JupiterSwapTask {',
+  '    /// The input token address.',
+  '    optional string in_token_address = 1;',
+  '    /// Optional Jupiter API key.',
+  '    ///',
+  '    /// Set this field to `${JUPITER_API_KEY}` and provide the matching non-empty value',
+  '    /// through variableOverrides when requesting the feed.',
+  '    /// An unresolved placeholder fails before contacting Jupiter.',
+  '    /// If this field is omitted or empty, the oracle configured key is used when available.',
+  '    optional string api_key = 12;',
+  '  }',
+  '',
+  '  /* Oracle docs. */',
+  '  message OracleTask {',
+  '    message PythConfigs {',
+  '      /// Optional Hermes base URL used by pyth_address tasks.',
+  '      optional string hermes_url = 1;',
+  '      /// Preferred Pyth confidence interval setting, expressed as a raw percentage.',
+  '      /// For example, use 10 to represent 10%, not 0.1.',
+  '      optional double pyth_allowed_confidence_interval = 2;',
+  '      /// Maximum accepted price age in seconds.',
+  '      /// Defaults to 15 seconds for pyth_address and 75 seconds for pyth_push_feed_id.',
+  '      optional int32 max_stale_seconds = 3;',
+  '      /// Pyth push-feed shard used only by pyth_push_feed_id. Defaults to shard 0.',
+  '      optional uint32 push_feed_shard_id = 4;',
+  '      /// Optional API key for authenticated Pyth Hermes requests made by pyth_address tasks.',
+  '      /// Use a variable placeholder such as `${PYTH_API_KEY}` and supply a matching non-empty variableOverrides value at execution time; do not hardcode credentials.',
+  '      /// This field takes precedence when it is non-empty. If it is omitted or empty, variableOverrides.PYTH_API_KEY is accepted as a compatibility fallback.',
+  '      /// That fallback is request-wide: the same value is used by every pyth_address task in the execution that does not configure its own api_key.',
+  '      /// Pyth push-feed tasks read on-chain accounts and do not use this API key.',
+  '      optional string api_key = 5;',
+  '    }',
+  '    oneof AggregatorAddress {',
+  '      /// Mainnet address for a Pyth feed.',
+  '      string pyth_address = 2;',
+  '      /// Pyth price feed ID for an upgraded Solana push feed.',
+  '      string pyth_push_feed_id = 12;',
+  '    }',
+  '    /// Optional settings for Pyth tasks.',
+  '    optional PythConfigs pyth_configs = 6;',
+  '  }',
+  '',
+  '  message EmptyTask {}',
+  '',
+  '  /* Value docs. */',
+  '  message ValueTask {',
+  '    message ValueConfig {',
+  '      /// This comment belongs only to ValueConfig.',
+  '      optional string value = 1;',
+  '    }',
+  '    /// Value-specific settings.',
+  '    optional ValueConfig config = 1;',
+  '  }',
+  '}'
+].join('\n');
+
+test('retains Jupiter multiline API key documentation', () => {
+  const tasks = parseTaskDocumentation(PROTO_FIXTURE);
+  const apiKey = tasks.get('JupiterSwapTask').fields.find(field => field.name === 'api_key');
+
+  assert.equal(
+    apiKey.description,
+    'Optional Jupiter API key. Set this field to `${JUPITER_API_KEY}` and provide the matching non-empty value through variableOverrides when requesting the feed. An unresolved placeholder fails before contacting Jupiter. If this field is omitted or empty, the oracle configured key is used when available.'
+  );
+});
+
+test('includes OracleTask Pyth fields declared in a oneof', () => {
+  const tasks = parseTaskDocumentation(PROTO_FIXTURE);
+  const fieldNames = tasks.get('OracleTask').fields.map(field => field.name);
+
+  assert.ok(fieldNames.includes('pyth_address'));
+  assert.ok(fieldNames.includes('pyth_push_feed_id'));
+});
+
+test('parses tasks after a single-line empty message', () => {
+  const tasks = parseTaskDocumentation(PROTO_FIXTURE);
+
+  assert.ok(tasks.has('EmptyTask'));
+  assert.ok(tasks.has('ValueTask'));
+});
+
+test('renders every documented PythConfigs field and the complete fallback behavior', () => {
+  const tasks = parseTaskDocumentation(PROTO_FIXTURE);
+  const pythConfigs = tasks.get('OracleTask').nestedMessages.get('PythConfigs');
+  const markdown = generateMarkdown(tasks);
+
+  assert.deepEqual(
+    pythConfigs.fields.map(field => field.name),
+    [
+      'hermes_url',
+      'pyth_allowed_confidence_interval',
+      'max_stale_seconds',
+      'push_feed_shard_id',
+      'api_key'
+    ]
+  );
+  assert.match(markdown, /\*\*PythConfigs fields\*\*/);
+  assert.match(markdown, /compatibility fallback/);
+  assert.match(markdown, /same value is used by every pyth_address task/);
+  assert.match(markdown, /Pyth push-feed tasks read on-chain accounts and do not use this API key/);
+});
+
+test('keeps nested comments with their owning message', () => {
+  const tasks = parseTaskDocumentation(PROTO_FIXTURE);
+  const oracleMarkdown = generateMarkdown(new Map([['OracleTask', tasks.get('OracleTask')]]));
+  const valueMarkdown = generateMarkdown(new Map([['ValueTask', tasks.get('ValueTask')]]));
+
+  assert.doesNotMatch(oracleMarkdown, /belongs only to ValueConfig/);
+  assert.match(valueMarkdown, /belongs only to ValueConfig/);
+});
+
+test('generates deterministic output', () => {
+  const first = generateMarkdown(parseTaskDocumentation(PROTO_FIXTURE));
+  const second = generateMarkdown(parseTaskDocumentation(PROTO_FIXTURE));
+
+  assert.equal(second, first);
+});


### PR DESCRIPTION
## Summary

- document the variable-override trust boundary for controlled and permissionless update paths
- explain Jupiter placeholder behavior and Pyth Hermes compatibility, precedence, request isolation, push feeds, and defaults
- teach the task generator to retain multiline comments, top-level oneof fields, and referenced nested configuration fields
- add dependency-free generator tests and regenerate the task reference from current sbv3 `main` after #1049

## Verification

- `node --test scripts/generate-task-docs.test.js`
- parsed all 76 task messages with no missing or unexpected tasks
- regenerated twice from current sbv3 `main` with identical SHA-256 output
- confirmed regeneration is byte-for-byte unchanged from the committed reference
- checked local Markdown links and anchors
- ran the user-docs boundary scanner
- ran `git diff --check` and secret-pattern scans

## Source

The generated reference uses the exact `job_schemas.proto` blob currently on `switchboard-xyz/sbv3` `main` after #1049 (`300a7d58d63d71192eed5de99348a087e233f77b`). PR #1049 restored the same proto documentation content originally used for this branch, so regeneration produced no diff.

## Existing workflow note

The existing standalone fallback fetches `raw.githubusercontent.com/switchboard-xyz/sbv3` without authentication. Because `sbv3` is private, that fallback currently returns 404 unless the workflow is given private-repository read access. Local sibling-repository generation remains unchanged.